### PR TITLE
Make lodash navbar smaller on docs page.

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -505,6 +505,17 @@ body.layout-docs {
   .doc-main {
     flex: 1 1 auto;
   }
+
+  header {
+    position: static;
+    min-height: 56px;
+    padding: 0;
+  }
+
+  .logo {
+    width: 40px;
+    height: 40px;
+  }
 }
 
 .mobile-menu {


### PR DESCRIPTION
This gives larger screen estate to the actual documentation. The menu for mobile shouldn’t be affected.

| Initial behaviour | New behaviour |
|---|---|
| ![Initial](https://cloud.githubusercontent.com/assets/813865/16543910/9cb8e650-4122-11e6-8558-5e6ed7b4d9a0.gif) | ![New](https://cloud.githubusercontent.com/assets/813865/16543913/a75cc5c2-4122-11e6-9d1f-5505ac2ba157.gif) |