### PR TITLE
Fixes to version select

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -16,6 +16,10 @@ bodyClass: 'documentation'
             {% for release in site.releases %}
               <option value="{{ release }}" {% if page.version == release %}selected{% endif %}>v{{ release }}</option>
             {% endfor %}
+            {% unless site.releases contains page.version %}
+              <option value="{{ page.version }}" selected>v{{ page.version }}</option>
+            {% endunless %}
+            <option value="1.3.1">v1.3.1</option>
           </select>
         </h1>
       </div>

--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -194,8 +194,12 @@
 
   versionSelect.addEventListener('change', function(e) {
     var value = e.target.value;
+
     if (value) {
-      location.href = '/docs/' + value;
+      location.href =
+        value === '1.3.1'
+        ? 'https://github.com/lodash/lodash/blob/1.3.1/doc/README.md'
+        : '/docs/' + value;
     }
   });
 }());


### PR DESCRIPTION
If the version of the page isn't in the version selector, add it and make it selected so the dropdown displays the right version. This will be important when there are more versions added, but not in the dropdown. E.g., when 4.14.0 is released, 4.13.1 will be removed from the dropdown but still available.

Also, add a link to legacy lodash 1.3.1 version that links to github since that page wasn't able to be ported.