### PR TITLE
style docs' `source` and `npm package` links

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -92,6 +92,20 @@ html.docs {
         margin: 0 -999rem;
         padding: 2rem 999rem;
       }
+
+      h3 + p a:first-child {
+        display: none;
+      }
+
+      h3 + p a {
+        color: #bababa;
+        font-size: 14px;
+        margin-right: 15px;
+
+        &:hover {
+          color: darken(#bababa, 15%);
+        }
+      }
     }
 
     div {


### PR DESCRIPTION
I removed the `#` link but I let you be the judge of that. I really think it belongs in front of the title (kind of like [bootstrap's docs](http://getbootstrap.com/css/ does it, but they show it on hover).

Is it possible to have classes to avoid these kind of funky selectors? (`html.docs .doc-container > div > div h3 + p a`)