### PR TITLE
Add statement on homepage about Lodash’s dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@ layout: default
     <li>Manipulating &amp; testing values</li>
     <li>Creating composite functions</li>
   </ul>
+  
+  <p>Lodash does not have any dependencies.</p>
 </section>
 
 <section>


### PR DESCRIPTION
**TL;DR;**

Another argument for "Why Lodash?" that I think is very relevant to today's ecosystem. While I don't think many people would expect a utility library to have dependencies, it is still worth stating.

---------------

The specific sentence I wrote isn't perfect. It overlooks the fact that some flavors of lodash do depend on other pieces of lodash – I think this is acceptable, since this is the same overall library it feels like an implementation detail. I'm not attached to the specific words either, if "zero dependencies" or "no external dependencies" sound better then 👍 . If the sentence would fit better elsewhere, 👍 .

I am proposing this change because I was surprised by the release of https://github.com/angus-c/just. There are a few things that this lib sells itself for that I think are very strong arguments for Lodash but are not documented enough:

- Lack of external dependencies (addressed by this PR)
- Package size – gzipped size of individual modular methods, and also the existence of the `babel` and `webpack` plugins (all of those things are mentioned in the docs, but without explaining why they matter).
- A third item would be performance – I think I know Lodash is fast, but all of the numbers I've seen have been from random blog posts and tweets rather than "official" info.

Now those 2 other items are a bit harder to address – just adding these here for the sake of completeness, but they should prob be discussed in separate issues.
