### PR TITLE
Fix Docs' scroll performance issues

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -66,6 +66,7 @@ html.docs {
     overflow-x: hidden;
     overflow-y: auto;
     padding: 1.5rem 2.5rem;
+    transform: translateZ(0);
 
     &:after {
       background: lightgrey;
@@ -195,7 +196,7 @@ html.docs {
     position: absolute;
     right: 0;
     top: 0;
-    transform: translateX(100%);
+    transform: translateX(100%) translateZ(0);
     transition: all 0.5s ease;
     white-space: nowrap;
     width: calc(200px + 2.5rem);

--- a/assets/css/_media-queries.scss
+++ b/assets/css/_media-queries.scss
@@ -10,7 +10,7 @@
       height: auto;
       min-width: 180px;
       position: relative;
-      transform: none;
+      transform: translateZ(0);
       transition: none;
     }
   }


### PR DESCRIPTION
Hey.

The documentation is a bit sluggish and stuttery when it comes to scroll...
I identified the issue, which is constant repaints on scroll and addressed it by promoting both TOC (`.toc-container`) and the content section (`.doc-container`) onto their own GPU layers.
Now the browsers are able to do the compositing cheaply on GPU, rather than repaint all the content all over again on scroll.

Let me know if that looks good and if you need anything else (more info?) from me. ;)

Thanks,
Daniel.