### PR TITLE
Focus on the search input by typing `/`

### DIFF
--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -74,6 +74,23 @@
       });
     },
 
+    'componentDidMount': function() {
+      document.addEventListener('keydown', this.handleDocumentKeyDown);
+    },
+
+    'componentWillUnmount': function() {
+      document.removeEventListener('keydown', this.handleDocumentKeyDown);
+    },
+
+    'handleDocumentKeyDown': function(e) {
+        // Has the user pressed `/`?
+        if (e.which === 191) {
+          this.searchNode.focus();
+          // Don't actually type a `/` in the input.
+          e.preventDefault();
+        }
+    },
+
     'onChangeExpanded': function(event, index) {
       this.setState({
         'content': this.state.content.update(index, function(collection) {
@@ -192,6 +209,10 @@
         );
       });
 
+      var searchRefCallback = function(node) {
+        _this.searchNode = node;
+      };
+
       return React.createElement(
         'div',
         {
@@ -215,7 +236,8 @@
               'placeholder': 'Search',
               'type': 'search',
               'value': this.state.searchValue,
-              'onChange': this.onChangeSearch
+              'onChange': this.onChangeSearch,
+              'ref': searchRefCallback
             }
           )
         ),


### PR DESCRIPTION
This is a common shortcut across many tools, including both Underscore and
Ramda's docs, so it should be intuitive to most devs.

I've confirmed that this does not interfere with typing `/` in the REPL.