### PR TITLE
Fix header not wrapping issue on Safari/iOS.

### DIFF
--- a/assets/css/_default.scss
+++ b/assets/css/_default.scss
@@ -120,13 +120,13 @@ header {
   .header-section {
     align-items: center;
     display: flex;
-    flex: 1;
+    flex: 1 1 auto;
     justify-content: center;
     margin: 0.5rem 1rem;
   }
 
   .header-section.logo-section {
-    flex: 3;
+    flex: 3 1 auto;
     justify-content: flex-start;
   }
 


### PR DESCRIPTION
Making it more explicit rather than relying on the shortcut fixes issue on Safari.