### PR TITLE
Tweak docs sidebar width & font size

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -194,6 +194,7 @@ html.docs {
     height: 100%;
     overflow-y: auto;
     padding: 2.5rem;
+    padding-right: 1.5rem;
     position: absolute;
     right: 0;
     top: 0;

--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -234,7 +234,7 @@ html.docs {
       li a {
         border: none;
         color: $altColor;
-        font-size: 0.8em;
+        font-size: 0.875rem;
 
         &:hover {
           color: darken($altColor, 50%);

--- a/assets/css/_media-queries.scss
+++ b/assets/css/_media-queries.scss
@@ -8,7 +8,7 @@
       box-shadow: 0 0 0.5rem $shadow;
       flex: 3 3 0;
       height: auto;
-      min-width: 180px;
+      min-width: 300px;
       position: relative;
       transform: translateZ(0);
       transition: none;


### PR DESCRIPTION
This eliminates the horizontal scroll, and slightly increases the font-size. Note that I've drastically increased the width of the sidebar, but this (IMO) plays well across all screen sizes.

To be merged along with #43. With it, the sidebar will be more readable.

WCAG AA color contrasts in another PR.