### PR TITLE
Update visibility when search value clicked

### DIFF
--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -91,17 +91,8 @@
         }
     },
 
-    'onChangeExpanded': function(event, index) {
-      this.setState({
-        'content': this.state.content.update(index, function(collection) {
-          return collection.set('expanded', !collection.get('expanded'));
-        })
-      });
-    },
-
-    'onChangeSearch': function(event) {
-      var searchValue = event.target.value,
-          searchFound = false;
+    'handleSearchChange': function(searchValue) {
+      var searchFound = false;
 
       this.setState({
         'content': this.state.content.map(function(collection) {
@@ -130,14 +121,25 @@
       });
     },
 
+    'onChangeExpanded': function(event, index) {
+      this.setState({
+        'content': this.state.content.update(index, function(collection) {
+          return collection.set('expanded', !collection.get('expanded'));
+        })
+      });
+    },
+
+    'onChangeSearch': function(event) {
+      var searchValue = event.target.value;
+      this.handleSearchChange(searchValue);
+    },
+
     'onClickFuncName': function() {
       // Close mobile menu.
       menuEl.classList.remove('open');
 
       // Empty search box.
-      this.setState({
-        'searchValue': ''
-      });
+      this.handleSearchChange('');
     },
 
     'shouldComponentUpdate': function(nextProps, nextState) {


### PR DESCRIPTION
So I found that the logic to update the visibility and state of the content wasn't being called when someone clicked on a search item and reset the `searchValue`.

To fix this I abstracted the meat of the update process into a separate method and call that from the `onChangeSearch`. 