### PR TITLE
Standardize font-size and em/rem units into rem

### DIFF
--- a/assets/css/_custom-builds.scss
+++ b/assets/css/_custom-builds.scss
@@ -1,7 +1,7 @@
 html.custom-builds {
 
   li .highlight {
-     margin-top: 0.5rem;
-     margin-bottom: 1rem;
+     margin-top: 0.8rem;
+     margin-bottom: 1.6rem;
   }
 }

--- a/assets/css/_default.scss
+++ b/assets/css/_default.scss
@@ -2,7 +2,8 @@ html {
   background-color: $background;
   box-sizing: border-box;
   color: $defaultColor;
-  font-size: 100%;
+  // Sets the base font-size to 10px, so any rem manipulation operates as base 10, ie. 2.4rem = 24px
+  font-size: 62.5%; // 10 / 16
   height: 100%;
 }
 
@@ -17,7 +18,7 @@ html, body, h1, h2, p {
 
 body {
   font-family: $fontFamily;
-  font-size: 1em;
+  font-size: 1.6rem;
   line-height: 1.5;
   min-height: 100%;
   overflow: auto;
@@ -41,7 +42,7 @@ a.btn {
   border: none;
   border-radius: 5px;
   color: $linkColor;
-  font-size: 0.8em;
+  font-size: 1.3rem;
   line-height: 1;
   padding: 17px 25px;
   white-space: nowrap;
@@ -71,18 +72,18 @@ h1, h2, h3, h4, h5, h6 {
   color: $defaultColor;
   font-weight: 400;
   letter-spacing: 0.5px;
-  margin-bottom: 1rem;
-  margin-top: 2rem;
+  margin-bottom: 1.6rem;
+  margin-top: 3.2rem;
 }
 
 ul, ol, p {
-  margin-bottom: 1rem;
-  margin-top: 1rem;
+  margin-bottom: 1.6rem;
+  margin-top: 1.6rem;
 }
 
 footer {
-  font-size: 0.75rem;
-  margin-bottom: 2rem;
+  font-size: 1.2rem;
+  margin-bottom: 3.2rem;
   text-align: center;
 
   .fa-heart {
@@ -92,9 +93,9 @@ footer {
 
 header {
   background-color: $foreground;
-  box-shadow: 0 0 1.4rem $shadow;
+  box-shadow: 0 0 2.25rem $shadow;
   min-height: 80px;
-  padding: 0.5rem 0;
+  padding: 0.8rem 0;
   position: relative;
   z-index: 2;
 
@@ -114,11 +115,11 @@ header {
     }
 
     h1 {
-      font-size: 1.4rem;
+      font-size: 2.2rem;
     }
 
     h2 {
-      font-size: 1rem;
+      font-size: 1.6rem;
     }
   }
 
@@ -127,7 +128,7 @@ header {
     display: flex;
     flex: 1 1 auto;
     justify-content: center;
-    margin: 0.5rem 1rem;
+    margin: 0.8rem 1.6rem;
   }
 
   .header-section.logo-section {
@@ -144,8 +145,8 @@ header {
     box-sizing: content-box;
     flex-shrink: 1;
     height: 80px;
-    margin-right: 1rem;
-    padding: 0 1rem 0 0;
+    margin-right: 1.6rem;
+    padding: 0 1.6rem 0 0;
     width: 80px;
 
     a {
@@ -166,14 +167,14 @@ pre, code {
 }
 
 section {
-  padding: 0 2.5rem;
+  padding: 0 4rem;
 
   &:not(:first-of-type) {
-    margin-top: 1rem;
+    margin-top: 1.6rem;
   }
 
   &:not(:last-of-type) {
-    margin-bottom: 1rem;
+    margin-bottom: 1.6rem;
   }
 }
 
@@ -183,20 +184,20 @@ ul {
   padding-left: 0;
 
   li {
-    padding-left: 1rem;
+    padding-left: 1.6rem;
   }
 
   li + li {
-    padding-top: 0.5rem;
+    padding-top: 0.8rem;
   }
 }
 
 ul.chevron li {
-  text-indent: -0.75rem;
+  text-indent: -1.2rem;
 
   &:before {
     content: "\203A";
-    padding-right: 0.5rem;
+    padding-right: 0.8rem;
   }
 
   .highlight {
@@ -211,11 +212,11 @@ ul.chevron li {
 
 .container.main {
   background-color: $foreground;
-  box-shadow: 0 4px 1.5rem -0.25rem $shadow;
-  margin-bottom: 2rem;
-  margin-top: 2rem;
+  box-shadow: 0 4px 2.4rem -0.4rem $shadow;
+  margin-bottom: 3.2rem;
+  margin-top: 3.2rem;
   overflow: hidden;
-  padding-bottom: 2rem;
+  padding-bottom: 3.2rem;
 }
 
 .highlight {
@@ -223,7 +224,7 @@ ul.chevron li {
   color: $codeColor;
   margin: 0 -999rem;
   overflow-x: auto;
-  padding: 2rem 999rem;
+  padding: 3.2rem 999rem;
   position: relative;
   -webkit-overflow-scrolling: touch;
 

--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -8,7 +8,7 @@ html.docs {
   a.anchor {
     border: none;
     color: $defaultNearColor;
-    margin-right: 1rem;
+    margin-right: 1.6rem;
 
     &:hover {
       color: $defaultColor;
@@ -18,7 +18,7 @@ html.docs {
   h3 {
     a {
       border-bottom: 0;
-      padding-right: 0.5rem;
+      padding-right: 0.8rem;
       visibility: hidden;
     }
 
@@ -38,7 +38,7 @@ html.docs {
     border: 1px solid $background;
     border-radius: 5px;
     color: $defaultColor;
-    font-size: 14px;
+    font-size: 1.4rem;
     height: 34px;
     line-height: 1.42857143;
     padding: 6px 12px;
@@ -50,9 +50,9 @@ html.docs {
   }
 
   .btn-repl {
-    bottom: 1.5rem;
+    bottom: 2.4rem;
     color: $foreground;
-    font-size: 0.8rem;
+    font-size: 1.3rem;
     position: absolute;
     right: 0;
   }
@@ -65,7 +65,7 @@ html.docs {
     flex: 14 14 0;
     overflow-x: hidden;
     overflow-y: auto;
-    padding: 1.5rem 2.5rem;
+    padding: 2.4rem 4rem;
     transform: translateZ(0);
     -webkit-overflow-scrolling: touch;
 
@@ -83,20 +83,20 @@ html.docs {
     }
 
     > div > div {
-      margin-bottom: 4rem;
-      padding: 0.5rem 0;
+      margin-bottom: 6.4rem;
+      padding: 0.8rem 0;
       position: relative;
 
       h3 {
         background-color: $background;
         margin: 0 -999rem;
-        padding: 2rem 999rem;
+        padding: 3.2rem 999rem;
       }
 
       h3 + p a {
         color: #bababa;
-        font-size: 0.9rem;
-        margin-right: 1rem;
+        font-size: 1.4rem;
+        margin-right: 1.6rem;
 
         &:hover {
           color: darken(#bababa, 15%);
@@ -115,11 +115,11 @@ html.docs {
 
       & + ol {
         list-style-type: none;
-        padding-left: 1rem;
+        padding-left: 1.6rem;
       }
 
       & + p {
-        padding-left: 1rem;
+        padding-left: 1.6rem;
       }
     }
 
@@ -167,7 +167,7 @@ html.docs {
     input {
       border: none;
       border-bottom: 2px solid $defaultLiteColor;
-      font-size: 0.8rem;
+      font-size: 1.3rem;
       padding: 10px 0;
       text-indent: 30px;
       width: 100%;
@@ -180,7 +180,7 @@ html.docs {
 
     .fa-search {
       color: #979797;
-      font-size: 15px;
+      font-size: 1.5rem;
       left: 7px;
       position: absolute;
       top: 9px;
@@ -192,14 +192,14 @@ html.docs {
     flex: none;
     height: 100%;
     overflow-y: auto;
-    padding: 1.5rem;
+    padding: 2.4rem;
     position: absolute;
     right: 0;
     top: 0;
     transform: translateX(100%) translateZ(0);
     transition: all 0.5s ease;
     white-space: nowrap;
-    width: calc(200px + 2.5rem);
+    width: calc(200px + 4rem);
     z-index: 1;
     -webkit-overflow-scrolling: touch;
 
@@ -209,12 +209,12 @@ html.docs {
 
     // Offset top to avoid page jank when the search bar loads.
     > div:first-child:not(.search):not(.react-menu-container) {
-      margin-top: calc(1.5rem + 37px);
+      margin-top: calc(2.4rem + 37px);
     }
 
     div > h2 {
-      margin-bottom: 0.5rem;
-      margin-top: 1.5rem;
+      margin-bottom: 0.8rem;
+      margin-top: 2.4rem;
 
       code {
         font-family: $fontFamily;
@@ -223,7 +223,7 @@ html.docs {
 
     ul {
       border-left: 1px dashed #dcdcdc;
-      margin-top: 0.5rem;
+      margin-top: 0.8rem;
 
       li {
         max-height: 40px;
@@ -232,7 +232,7 @@ html.docs {
       li a {
         border: none;
         color: $altColor;
-        font-size: 0.875rem;
+        font-size: 1.4rem;
 
         &:hover {
           color: darken($altColor, 50%);
@@ -242,8 +242,8 @@ html.docs {
 
     .empty-state {
       color: #bababa;
-      margin-top: 1.5rem;
-      font-size: 0.9em;
+      margin-top: 2.4rem;
+      font-size: 1.4rem;
     }
 
     .first-heading {
@@ -252,8 +252,8 @@ html.docs {
 
     .fa-minus-square-o, .fa-plus-square-o {
       cursor: pointer;
-      font-size: 14px;
-      margin-right: 0.7rem;
+      font-size: 1.4rem;
+      margin-right: 1.1rem;
     }
   }
 

--- a/assets/css/_home.scss
+++ b/assets/css/_home.scss
@@ -1,6 +1,6 @@
 html.home {
   div.intro {
-    font-size: 1.2rem;
+    font-size: 1.9rem;
   }
 
   section {

--- a/assets/css/_media-queries.scss
+++ b/assets/css/_media-queries.scss
@@ -35,20 +35,22 @@
 
 @media (max-width: $screen-md-max) {
   section {
-    padding: 0.5rem 1rem;
+    padding: 0.8rem 1.6rem;
   }
 
   .container.main {
-    margin: 1rem;
+    margin: 1.6rem;
   }
 }
 
 @media (max-width: $screen-lg-max) {
   html {
-    font-size: 0.875rem; // Makes body text 14px: 14/16 = 0.875.
+    // Makes the font-size 8.75px
+    // thus scaling body to 14px: 8.75px * 1.6 = 14px
+    font-size: 54.6875%; // 0.625 * 14 / 16
   }
 
   .container.main {
-    margin: 2rem;
+    margin: 3.2rem;
   }
 }


### PR DESCRIPTION
See #57, I've converted the root (html) font-size to 62.5%, and divided any em/rem by 0.625. This makes rem scaling on a much easier to read, base 10: 24px = 2.4rem.