### PR TITLE
Update text colors and weight for legibility, closes #56

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -79,18 +79,23 @@ html.docs {
 
       h3 {
         background-color: $background;
+        font-weight: 700;
         margin: 0 -999rem;
         padding: 3.2rem 999rem;
       }
 
       h3 + p a {
-        color: #bababa;
+        color: #9e9e9e;
         font-size: 1.4rem;
         margin-right: 1.6rem;
 
         &:hover {
-          color: darken(#bababa, 15%);
+          color: darken(#9e9e9e, 15%);
         }
+      }
+
+      h4 {
+        font-weight: 700;
       }
     }
 
@@ -220,11 +225,11 @@ html.docs {
 
       li a {
         border: none;
-        color: $altColor;
+        color: $defaultColor;
         font-size: 1.4rem;
 
         &:hover {
-          color: darken($altColor, 50%);
+          color: darken($defaultColor, 50%);
         }
       }
     }

--- a/assets/css/_variables.scss
+++ b/assets/css/_variables.scss
@@ -11,7 +11,7 @@ $defaultColor: #5f5f5f;
 $defaultLiteColor: lighten($defaultColor, 40%);
 $defaultNearColor: lighten($defaultColor, 20%);
 $foreground: #fff;
-$linkColor: #5572b8;
+$linkColor: #5885f1;
 $linkUnderline: #d4d4d4;
 $shadow: #9da5ab;
 


### PR DESCRIPTION
I've updated some text colors, mostly in the sidebar, and links. Also, I've made the methods headings bold (debatable, let me know what you think), as well as the subheadings.

I don't have a crappy monitor at hand to test contrasts, so feedback on the legibility of the new link color on a TN panel would be nice! It's now lighter, but it should have a better contrast with the body text. Still torn up between #5885f1 and #4b71ca.