### PR TITLE
fix: vendor build step clashed with vendor/bundle dir

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,2 @@
 ---
-BUNDLE_PATH: "vendor/bundle"
+BUNDLE_PATH: ".bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.log
 _site
 node_modules
+.bundle/*
+!.bundle/config

--- a/_config.yml
+++ b/_config.yml
@@ -100,7 +100,7 @@ exclude:
   - icons.js
   - LICENSE
   - package.json
-  - vendor
+  - package-lock.json
   - .bundle
   - "*.lock"
   - "*.log"


### PR DESCRIPTION
point ruby's bundler to install deps in .bundle dir instead of the vendor/bundle dir (this only matters for local dev, netlify should use its own location)

the build system uses vendor/ to install CDN assets, so we dont want those to collide

specifically, previous commit had told jekyll to ignore the vendor dir after they had pointed the bundler to install deps there. but in reality we need that vendor dir to be part of the build for now

also exclyded package-lock.json from jekyll, as it was ending up being shipped to prod

 ### Context
 
- closes https://github.com/lodash/lodash.com/issues/294
- closes https://github.com/lodash/lodash.com/issues/292
- closes https://github.com/lodash/lodash.com/issues/289
- closes https://github.com/lodash/lodash.com/issues/290
- closes https://github.com/lodash/lodash.com/issues/287
- closes https://github.com/lodash/lodash.com/issues/296