### PR TITLE
Removed '/vendor/' from script tag in doc page (#6051)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,7 +47,7 @@ sass:
 
 builds:
   *release:
-    href: https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js
+    href: cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js
     integrity: sha384-9STIK/s/5av47VsUK9w+PMhEpgZTkKW+wvmRSjU+Lx9DSrl5RdjHeOLhyNhuoYtY
 
   3.10.1:
@@ -75,12 +75,6 @@ vendor:
     - href: https://cdn.jsdelivr.net/fontawesome/4.7.0/css/font-awesome.min.css
       integrity: sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN
 
-  js:
-    - href: https://embed.runkit.com/
-      async: true
-
-    - href: https://cdn.jsdelivr.net/g/fuse@2.6.1,react@15.4.0(react.min.js+react-dom.min.js
-      integrity: sha384-txLSiuN1HJSO1or/mE1Y6bvgD0cV3WA6Ss7rs9WqvPQ3zthR8w/DzHpB+DVTDAMz
 
 carbon_ads:
   href: https://cdn.carbonads.com/carbon.js?serve=CW7ILKQY&placement=lodashdev&format=cover


### PR DESCRIPTION
Removed '/vendor/' from `src="/vendor/cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js"` fixing issue (#6051)

Approach:

- Removed "https://" from the commented line present in "_config.yml" file
<img width="1047" height="179" alt="Screenshot 2025-11-18 151204" src="https://github.com/user-attachments/assets/7848a5c7-a2b0-4cb7-bdad-dc2c5b576100" />

- Removed whole js section from "_config.yml" file
<img width="1118" height="195" alt="Screenshot 2025-11-18 151239" src="https://github.com/user-attachments/assets/eb844a3f-bf95-409f-897b-e6208c145c8d" />

 