### PR TITLE
update docs to 4.17.21

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 repository: lodash/lodash.com
 
 release:
-  &release 4.17.15
+  &release 4.17.21
 
 releases:
   - *release
@@ -47,8 +47,8 @@ sass:
 
 builds:
   *release:
-    href: https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js
-    integrity: sha384-9STIK/s/5av47VsUK9w+PMhEpgZTkKW+wvmRSjU+Lx9DSrl5RdjHeOLhyNhuoYtY
+    href: https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js
+    integrity: sha384-H6KKS1H1WwuERMSm+54dYLzjg0fKqRK5ZRyASdbrI/lwrCc6bXEmtGYr5SwvP1pZ
 
   3.10.1:
     href: https://cdn.jsdelivr.net/lodash/3.10.1/lodash.min.js

--- a/docs/4.17.21.html
+++ b/docs/4.17.21.html
@@ -2,7 +2,7 @@
 id: docs
 layout: docs
 title: Lodash Documentation
-version: 4.17.15
+version: 4.17.21
 ---
 
 {% raw %}
@@ -402,7 +402,7 @@ version: 4.17.15
 <h2><code>&#x201C;Array&#x201D; Methods</code></h2>
 <div>
 <h3 id="chunk"><a href="#chunk" class="fa fa-link"></a><code>_.chunk(array, [size=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L6839">source</a> <a href="https://www.npmjs.com/package/lodash.chunk">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L6903">source</a> <a href="https://www.npmjs.com/package/lodash.chunk">npm package</a></p>
 <p>Creates an array of elements split into groups the length of <code>size</code>.
 If <code>array</code> can&apos;t be split evenly, the final chunk will be the remaining
 elements.</p>
@@ -421,7 +421,7 @@ elements.</p>
 </div>
 <div>
 <h3 id="compact"><a href="#compact" class="fa fa-link"></a><code>_.compact(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L6874">source</a> <a href="https://www.npmjs.com/package/lodash.compact">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L6938">source</a> <a href="https://www.npmjs.com/package/lodash.compact">npm package</a></p>
 <p>Creates an array with all falsey values removed. The values <code>false</code>, <code>null</code>,
 <code>0</code>, <code>&quot;&quot;</code>, <code>undefined</code>, and <code>NaN</code> are falsey.</p>
 <h4>Since</h4>
@@ -438,7 +438,7 @@ elements.</p>
 </div>
 <div>
 <h3 id="concat"><a href="#concat" class="fa fa-link"></a><code>_.concat(array, [values])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L6911">source</a> <a href="https://www.npmjs.com/package/lodash.concat">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L6975">source</a> <a href="https://www.npmjs.com/package/lodash.concat">npm package</a></p>
 <p>Creates a new array concatenating <code>array</code> with any additional arrays
 and/or values.</p>
 <h4>Since</h4>
@@ -456,7 +456,7 @@ and/or values.</p>
 </div>
 <div>
 <h3 id="difference"><a href="#difference" class="fa fa-link"></a><code>_.difference(array, [values])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L6947">source</a> <a href="https://www.npmjs.com/package/lodash.difference">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7011">source</a> <a href="https://www.npmjs.com/package/lodash.difference">npm package</a></p>
 <p>Creates an array of <code>array</code> values not included in the other given arrays
 using <a href="http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero"><code>SameValueZero</code></a>
 for equality comparisons. The order and references of result values are
@@ -479,7 +479,7 @@ determined by the first array.
 </div>
 <div>
 <h3 id="differenceBy"><a href="#differenceBy" class="fa fa-link"></a><code>_.differenceBy(array, [values], [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L6979">source</a> <a href="https://www.npmjs.com/package/lodash.differenceby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7043">source</a> <a href="https://www.npmjs.com/package/lodash.differenceby">npm package</a></p>
 <p>This method is like <a href="#difference"><code>_.difference</code></a> except that it accepts <code>iteratee</code> which
 is invoked for each element of <code>array</code> and <code>values</code> to generate the criterion
 by which they&apos;re compared. The order and references of result values are
@@ -504,7 +504,7 @@ determined by the first array. The iteratee is invoked with one argument:<br>
 </div>
 <div>
 <h3 id="differenceWith"><a href="#differenceWith" class="fa fa-link"></a><code>_.differenceWith(array, [values], [comparator])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7012">source</a> <a href="https://www.npmjs.com/package/lodash.differencewith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7076">source</a> <a href="https://www.npmjs.com/package/lodash.differencewith">npm package</a></p>
 <p>This method is like <a href="#difference"><code>_.difference</code></a> except that it accepts <code>comparator</code>
 which is invoked to compare elements of <code>array</code> to <code>values</code>. The order and
 references of result values are determined by the first array. The comparator
@@ -528,7 +528,7 @@ is invoked with two arguments: <em>(arrVal, othVal)</em>.
 </div>
 <div>
 <h3 id="drop"><a href="#drop" class="fa fa-link"></a><code>_.drop(array, [n=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7047">source</a> <a href="https://www.npmjs.com/package/lodash.drop">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7111">source</a> <a href="https://www.npmjs.com/package/lodash.drop">npm package</a></p>
 <p>Creates a slice of <code>array</code> with <code>n</code> elements dropped from the beginning.</p>
 <h4>Since</h4>
 <p>0.5.0</p>
@@ -545,7 +545,7 @@ is invoked with two arguments: <em>(arrVal, othVal)</em>.
 </div>
 <div>
 <h3 id="dropRight"><a href="#dropRight" class="fa fa-link"></a><code>_.dropRight(array, [n=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7081">source</a> <a href="https://www.npmjs.com/package/lodash.dropright">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7145">source</a> <a href="https://www.npmjs.com/package/lodash.dropright">npm package</a></p>
 <p>Creates a slice of <code>array</code> with <code>n</code> elements dropped from the end.</p>
 <h4>Since</h4>
 <p>3.0.0</p>
@@ -562,7 +562,7 @@ is invoked with two arguments: <em>(arrVal, othVal)</em>.
 </div>
 <div>
 <h3 id="dropRightWhile"><a href="#dropRightWhile" class="fa fa-link"></a><code>_.dropRightWhile(array, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7126">source</a> <a href="https://www.npmjs.com/package/lodash.droprightwhile">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7190">source</a> <a href="https://www.npmjs.com/package/lodash.droprightwhile">npm package</a></p>
 <p>Creates a slice of <code>array</code> excluding elements dropped from the end.
 Elements are dropped until <code>predicate</code> returns falsey. The predicate is
 invoked with three arguments: <em>(value, index, array)</em>.</p>
@@ -581,7 +581,7 @@ invoked with three arguments: <em>(value, index, array)</em>.</p>
 </div>
 <div>
 <h3 id="dropWhile"><a href="#dropWhile" class="fa fa-link"></a><code>_.dropWhile(array, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7167">source</a> <a href="https://www.npmjs.com/package/lodash.dropwhile">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7231">source</a> <a href="https://www.npmjs.com/package/lodash.dropwhile">npm package</a></p>
 <p>Creates a slice of <code>array</code> excluding elements dropped from the beginning.
 Elements are dropped until <code>predicate</code> returns falsey. The predicate is
 invoked with three arguments: <em>(value, index, array)</em>.</p>
@@ -600,7 +600,7 @@ invoked with three arguments: <em>(value, index, array)</em>.</p>
 </div>
 <div>
 <h3 id="fill"><a href="#fill" class="fa fa-link"></a><code>_.fill(array, value, [start=0], [end=array.length])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7202">source</a> <a href="https://www.npmjs.com/package/lodash.fill">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7266">source</a> <a href="https://www.npmjs.com/package/lodash.fill">npm package</a></p>
 <p>Fills elements of <code>array</code> with <code>value</code> from <code>start</code> up to, but not
 including, <code>end</code>.
 <br>
@@ -623,7 +623,7 @@ including, <code>end</code>.
 </div>
 <div>
 <h3 id="findIndex"><a href="#findIndex" class="fa fa-link"></a><code>_.findIndex(array, [predicate=_.identity], [fromIndex=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7249">source</a> <a href="https://www.npmjs.com/package/lodash.findindex">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7313">source</a> <a href="https://www.npmjs.com/package/lodash.findindex">npm package</a></p>
 <p>This method is like <a href="#find"><code>_.find</code></a> except that it returns the index of the first
 element <code>predicate</code> returns truthy for instead of the element itself.</p>
 <h4>Since</h4>
@@ -642,7 +642,7 @@ element <code>predicate</code> returns truthy for instead of the element itself.
 </div>
 <div>
 <h3 id="findLastIndex"><a href="#findLastIndex" class="fa fa-link"></a><code>_.findLastIndex(array, [predicate=_.identity], [fromIndex=array.length-1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7296">source</a> <a href="https://www.npmjs.com/package/lodash.findlastindex">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7360">source</a> <a href="https://www.npmjs.com/package/lodash.findlastindex">npm package</a></p>
 <p>This method is like <a href="#findIndex"><code>_.findIndex</code></a> except that it iterates over elements
 of <code>collection</code> from right to left.</p>
 <h4>Since</h4>
@@ -661,7 +661,7 @@ of <code>collection</code> from right to left.</p>
 </div>
 <div>
 <h3 id="flatten"><a href="#flatten" class="fa fa-link"></a><code>_.flatten(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7325">source</a> <a href="https://www.npmjs.com/package/lodash.flatten">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7389">source</a> <a href="https://www.npmjs.com/package/lodash.flatten">npm package</a></p>
 <p>Flattens <code>array</code> a single level deep.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -677,7 +677,7 @@ of <code>collection</code> from right to left.</p>
 </div>
 <div>
 <h3 id="flattenDeep"><a href="#flattenDeep" class="fa fa-link"></a><code>_.flattenDeep(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7344">source</a> <a href="https://www.npmjs.com/package/lodash.flattendeep">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7408">source</a> <a href="https://www.npmjs.com/package/lodash.flattendeep">npm package</a></p>
 <p>Recursively flattens <code>array</code>.</p>
 <h4>Since</h4>
 <p>3.0.0</p>
@@ -693,7 +693,7 @@ of <code>collection</code> from right to left.</p>
 </div>
 <div>
 <h3 id="flattenDepth"><a href="#flattenDepth" class="fa fa-link"></a><code>_.flattenDepth(array, [depth=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7369">source</a> <a href="https://www.npmjs.com/package/lodash.flattendepth">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7433">source</a> <a href="https://www.npmjs.com/package/lodash.flattendepth">npm package</a></p>
 <p>Recursively flatten <code>array</code> up to <code>depth</code> times.</p>
 <h4>Since</h4>
 <p>4.4.0</p>
@@ -710,7 +710,7 @@ of <code>collection</code> from right to left.</p>
 </div>
 <div>
 <h3 id="fromPairs"><a href="#fromPairs" class="fa fa-link"></a><code>_.fromPairs(pairs)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7393">source</a> <a href="https://www.npmjs.com/package/lodash.frompairs">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7457">source</a> <a href="https://www.npmjs.com/package/lodash.frompairs">npm package</a></p>
 <p>The inverse of <a href="#toPairs"><code>_.toPairs</code></a>; this method returns an object composed
 from key-value <code>pairs</code>.</p>
 <h4>Since</h4>
@@ -727,7 +727,7 @@ from key-value <code>pairs</code>.</p>
 </div>
 <div>
 <h3 id="head"><a href="#head" class="fa fa-link"></a><code>_.head(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7423">source</a> <a href="https://www.npmjs.com/package/lodash.head">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7487">source</a> <a href="https://www.npmjs.com/package/lodash.head">npm package</a></p>
 <p>Gets the first element of <code>array</code>.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -745,7 +745,7 @@ from key-value <code>pairs</code>.</p>
 </div>
 <div>
 <h3 id="indexOf"><a href="#indexOf" class="fa fa-link"></a><code>_.indexOf(array, value, [fromIndex=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7450">source</a> <a href="https://www.npmjs.com/package/lodash.indexof">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7514">source</a> <a href="https://www.npmjs.com/package/lodash.indexof">npm package</a></p>
 <p>Gets the index at which the first occurrence of <code>value</code> is found in <code>array</code>
 using <a href="http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero"><code>SameValueZero</code></a>
 for equality comparisons. If <code>fromIndex</code> is negative, it&apos;s used as the
@@ -766,7 +766,7 @@ offset from the end of <code>array</code>.</p>
 </div>
 <div>
 <h3 id="initial"><a href="#initial" class="fa fa-link"></a><code>_.initial(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7476">source</a> <a href="https://www.npmjs.com/package/lodash.initial">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7540">source</a> <a href="https://www.npmjs.com/package/lodash.initial">npm package</a></p>
 <p>Gets all but the last element of <code>array</code>.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -782,7 +782,7 @@ offset from the end of <code>array</code>.</p>
 </div>
 <div>
 <h3 id="intersection"><a href="#intersection" class="fa fa-link"></a><code>_.intersection([arrays])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7498">source</a> <a href="https://www.npmjs.com/package/lodash.intersection">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7562">source</a> <a href="https://www.npmjs.com/package/lodash.intersection">npm package</a></p>
 <p>Creates an array of unique values that are included in all given arrays
 using <a href="http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero"><code>SameValueZero</code></a>
 for equality comparisons. The order and references of result values are
@@ -801,7 +801,7 @@ determined by the first array.</p>
 </div>
 <div>
 <h3 id="intersectionBy"><a href="#intersectionBy" class="fa fa-link"></a><code>_.intersectionBy([arrays], [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7528">source</a> <a href="https://www.npmjs.com/package/lodash.intersectionby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7592">source</a> <a href="https://www.npmjs.com/package/lodash.intersectionby">npm package</a></p>
 <p>This method is like <a href="#intersection"><code>_.intersection</code></a> except that it accepts <code>iteratee</code>
 which is invoked for each element of each <code>arrays</code> to generate the criterion
 by which they&apos;re compared. The order and references of result values are
@@ -822,7 +822,7 @@ determined by the first array. The iteratee is invoked with one argument:<br>
 </div>
 <div>
 <h3 id="intersectionWith"><a href="#intersectionWith" class="fa fa-link"></a><code>_.intersectionWith([arrays], [comparator])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7563">source</a> <a href="https://www.npmjs.com/package/lodash.intersectionwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7627">source</a> <a href="https://www.npmjs.com/package/lodash.intersectionwith">npm package</a></p>
 <p>This method is like <a href="#intersection"><code>_.intersection</code></a> except that it accepts <code>comparator</code>
 which is invoked to compare elements of <code>arrays</code>. The order and references
 of result values are determined by the first array. The comparator is
@@ -842,7 +842,7 @@ invoked with two arguments: <em>(arrVal, othVal)</em>.</p>
 </div>
 <div>
 <h3 id="join"><a href="#join" class="fa fa-link"></a><code>_.join(array, [separator=&apos;,&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7591">source</a> <a href="https://www.npmjs.com/package/lodash.join">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7655">source</a> <a href="https://www.npmjs.com/package/lodash.join">npm package</a></p>
 <p>Converts all elements in <code>array</code> into a string separated by <code>separator</code>.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -859,7 +859,7 @@ invoked with two arguments: <em>(arrVal, othVal)</em>.</p>
 </div>
 <div>
 <h3 id="last"><a href="#last" class="fa fa-link"></a><code>_.last(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7609">source</a> <a href="https://www.npmjs.com/package/lodash.last">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7673">source</a> <a href="https://www.npmjs.com/package/lodash.last">npm package</a></p>
 <p>Gets the last element of <code>array</code>.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -875,7 +875,7 @@ invoked with two arguments: <em>(arrVal, othVal)</em>.</p>
 </div>
 <div>
 <h3 id="lastIndexOf"><a href="#lastIndexOf" class="fa fa-link"></a><code>_.lastIndexOf(array, value, [fromIndex=array.length-1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7635">source</a> <a href="https://www.npmjs.com/package/lodash.lastindexof">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7699">source</a> <a href="https://www.npmjs.com/package/lodash.lastindexof">npm package</a></p>
 <p>This method is like <a href="#indexOf"><code>_.indexOf</code></a> except that it iterates over elements of
 <code>array</code> from right to left.</p>
 <h4>Since</h4>
@@ -894,7 +894,7 @@ invoked with two arguments: <em>(arrVal, othVal)</em>.</p>
 </div>
 <div>
 <h3 id="nth"><a href="#nth" class="fa fa-link"></a><code>_.nth(array, [n=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7671">source</a> <a href="https://www.npmjs.com/package/lodash.nth">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7735">source</a> <a href="https://www.npmjs.com/package/lodash.nth">npm package</a></p>
 <p>Gets the element at index <code>n</code> of <code>array</code>. If <code>n</code> is negative, the nth
 element from the end is returned.</p>
 <h4>Since</h4>
@@ -912,7 +912,7 @@ element from the end is returned.</p>
 </div>
 <div>
 <h3 id="pull"><a href="#pull" class="fa fa-link"></a><code>_.pull(array, [values])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7698">source</a> <a href="https://www.npmjs.com/package/lodash.pull">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7762">source</a> <a href="https://www.npmjs.com/package/lodash.pull">npm package</a></p>
 <p>Removes all given values from <code>array</code> using
 <a href="http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero"><code>SameValueZero</code></a>
 for equality comparisons.
@@ -935,7 +935,7 @@ to remove elements from an array by predicate.</p>
 </div>
 <div>
 <h3 id="pullAll"><a href="#pullAll" class="fa fa-link"></a><code>_.pullAll(array, values)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7720">source</a> <a href="https://www.npmjs.com/package/lodash.pullall">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7784">source</a> <a href="https://www.npmjs.com/package/lodash.pullall">npm package</a></p>
 <p>This method is like <a href="#pull"><code>_.pull</code></a> except that it accepts an array of values to remove.
 <br>
 <br>
@@ -955,7 +955,7 @@ to remove elements from an array by predicate.</p>
 </div>
 <div>
 <h3 id="pullAllBy"><a href="#pullAllBy" class="fa fa-link"></a><code>_.pullAllBy(array, values, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7749">source</a> <a href="https://www.npmjs.com/package/lodash.pullallby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7813">source</a> <a href="https://www.npmjs.com/package/lodash.pullallby">npm package</a></p>
 <p>This method is like <a href="#pullAll"><code>_.pullAll</code></a> except that it accepts <code>iteratee</code> which is
 invoked for each element of <code>array</code> and <code>values</code> to generate the criterion
 by which they&apos;re compared. The iteratee is invoked with one argument: <em>(value)</em>.
@@ -978,7 +978,7 @@ by which they&apos;re compared. The iteratee is invoked with one argument: <em>(
 </div>
 <div>
 <h3 id="pullAllWith"><a href="#pullAllWith" class="fa fa-link"></a><code>_.pullAllWith(array, values, [comparator])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7778">source</a> <a href="https://www.npmjs.com/package/lodash.pullallwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7842">source</a> <a href="https://www.npmjs.com/package/lodash.pullallwith">npm package</a></p>
 <p>This method is like <a href="#pullAll"><code>_.pullAll</code></a> except that it accepts <code>comparator</code> which
 is invoked to compare elements of <code>array</code> to <code>values</code>. The comparator is
 invoked with two arguments: <em>(arrVal, othVal)</em>.
@@ -1001,7 +1001,7 @@ invoked with two arguments: <em>(arrVal, othVal)</em>.
 </div>
 <div>
 <h3 id="pullAt"><a href="#pullAt" class="fa fa-link"></a><code>_.pullAt(array, [indexes])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7808">source</a> <a href="https://www.npmjs.com/package/lodash.pullat">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7872">source</a> <a href="https://www.npmjs.com/package/lodash.pullat">npm package</a></p>
 <p>Removes elements from <code>array</code> corresponding to <code>indexes</code> and returns an
 array of removed elements.
 <br>
@@ -1022,7 +1022,7 @@ array of removed elements.
 </div>
 <div>
 <h3 id="remove"><a href="#remove" class="fa fa-link"></a><code>_.remove(array, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7847">source</a> <a href="https://www.npmjs.com/package/lodash.remove">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7911">source</a> <a href="https://www.npmjs.com/package/lodash.remove">npm package</a></p>
 <p>Removes all elements from <code>array</code> that <code>predicate</code> returns truthy for
 and returns an array of the removed elements. The predicate is invoked
 with three arguments: <em>(value, index, array)</em>.
@@ -1045,7 +1045,7 @@ to pull elements from an array by value.</p>
 </div>
 <div>
 <h3 id="reverse"><a href="#reverse" class="fa fa-link"></a><code>_.reverse(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7891">source</a> <a href="https://www.npmjs.com/package/lodash.reverse">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7955">source</a> <a href="https://www.npmjs.com/package/lodash.reverse">npm package</a></p>
 <p>Reverses <code>array</code> so that the first element becomes the last, the second
 element becomes the second to last, and so on.
 <br>
@@ -1066,7 +1066,7 @@ element becomes the second to last, and so on.
 </div>
 <div>
 <h3 id="slice"><a href="#slice" class="fa fa-link"></a><code>_.slice(array, [start=0], [end=array.length])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7911">source</a> <a href="https://www.npmjs.com/package/lodash.slice">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L7975">source</a> <a href="https://www.npmjs.com/package/lodash.slice">npm package</a></p>
 <p>Creates a slice of <code>array</code> from <code>start</code> up to, but not including, <code>end</code>.
 <br>
 <br>
@@ -1087,7 +1087,7 @@ returned.</p>
 </div>
 <div>
 <h3 id="sortedIndex"><a href="#sortedIndex" class="fa fa-link"></a><code>_.sortedIndex(array, value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7944">source</a> <a href="https://www.npmjs.com/package/lodash.sortedindex">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8008">source</a> <a href="https://www.npmjs.com/package/lodash.sortedindex">npm package</a></p>
 <p>Uses a binary search to determine the lowest index at which <code>value</code>
 should be inserted into <code>array</code> in order to maintain its sort order.</p>
 <h4>Since</h4>
@@ -1105,7 +1105,7 @@ should be inserted into <code>array</code> in order to maintain its sort order.<
 </div>
 <div>
 <h3 id="sortedIndexBy"><a href="#sortedIndexBy" class="fa fa-link"></a><code>_.sortedIndexBy(array, value, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7973">source</a> <a href="https://www.npmjs.com/package/lodash.sortedindexby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8037">source</a> <a href="https://www.npmjs.com/package/lodash.sortedindexby">npm package</a></p>
 <p>This method is like <a href="#sortedIndex"><code>_.sortedIndex</code></a> except that it accepts <code>iteratee</code>
 which is invoked for <code>value</code> and each element of <code>array</code> to compute their
 sort ranking. The iteratee is invoked with one argument: <em>(value)</em>.</p>
@@ -1125,7 +1125,7 @@ sort ranking. The iteratee is invoked with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="sortedIndexOf"><a href="#sortedIndexOf" class="fa fa-link"></a><code>_.sortedIndexOf(array, value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L7993">source</a> <a href="https://www.npmjs.com/package/lodash.sortedindexof">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8057">source</a> <a href="https://www.npmjs.com/package/lodash.sortedindexof">npm package</a></p>
 <p>This method is like <a href="#indexOf"><code>_.indexOf</code></a> except that it performs a binary
 search on a sorted <code>array</code>.</p>
 <h4>Since</h4>
@@ -1143,7 +1143,7 @@ search on a sorted <code>array</code>.</p>
 </div>
 <div>
 <h3 id="sortedLastIndex"><a href="#sortedLastIndex" class="fa fa-link"></a><code>_.sortedLastIndex(array, value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8022">source</a> <a href="https://www.npmjs.com/package/lodash.sortedlastindex">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8086">source</a> <a href="https://www.npmjs.com/package/lodash.sortedlastindex">npm package</a></p>
 <p>This method is like <a href="#sortedIndex"><code>_.sortedIndex</code></a> except that it returns the highest
 index at which <code>value</code> should be inserted into <code>array</code> in order to
 maintain its sort order.</p>
@@ -1162,7 +1162,7 @@ maintain its sort order.</p>
 </div>
 <div>
 <h3 id="sortedLastIndexBy"><a href="#sortedLastIndexBy" class="fa fa-link"></a><code>_.sortedLastIndexBy(array, value, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8051">source</a> <a href="https://www.npmjs.com/package/lodash.sortedlastindexby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8115">source</a> <a href="https://www.npmjs.com/package/lodash.sortedlastindexby">npm package</a></p>
 <p>This method is like <a href="#sortedLastIndex"><code>_.sortedLastIndex</code></a> except that it accepts <code>iteratee</code>
 which is invoked for <code>value</code> and each element of <code>array</code> to compute their
 sort ranking. The iteratee is invoked with one argument: <em>(value)</em>.</p>
@@ -1182,7 +1182,7 @@ sort ranking. The iteratee is invoked with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="sortedLastIndexOf"><a href="#sortedLastIndexOf" class="fa fa-link"></a><code>_.sortedLastIndexOf(array, value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8071">source</a> <a href="https://www.npmjs.com/package/lodash.sortedlastindexof">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8135">source</a> <a href="https://www.npmjs.com/package/lodash.sortedlastindexof">npm package</a></p>
 <p>This method is like <a href="#lastIndexOf"><code>_.lastIndexOf</code></a> except that it performs a binary
 search on a sorted <code>array</code>.</p>
 <h4>Since</h4>
@@ -1200,7 +1200,7 @@ search on a sorted <code>array</code>.</p>
 </div>
 <div>
 <h3 id="sortedUniq"><a href="#sortedUniq" class="fa fa-link"></a><code>_.sortedUniq(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8097">source</a> <a href="https://www.npmjs.com/package/lodash.sorteduniq">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8161">source</a> <a href="https://www.npmjs.com/package/lodash.sorteduniq">npm package</a></p>
 <p>This method is like <a href="#uniq"><code>_.uniq</code></a> except that it&apos;s designed and optimized
 for sorted arrays.</p>
 <h4>Since</h4>
@@ -1217,7 +1217,7 @@ for sorted arrays.</p>
 </div>
 <div>
 <h3 id="sortedUniqBy"><a href="#sortedUniqBy" class="fa fa-link"></a><code>_.sortedUniqBy(array, [iteratee])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8119">source</a> <a href="https://www.npmjs.com/package/lodash.sorteduniqby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8183">source</a> <a href="https://www.npmjs.com/package/lodash.sorteduniqby">npm package</a></p>
 <p>This method is like <a href="#uniqBy"><code>_.uniqBy</code></a> except that it&apos;s designed and optimized
 for sorted arrays.</p>
 <h4>Since</h4>
@@ -1235,7 +1235,7 @@ for sorted arrays.</p>
 </div>
 <div>
 <h3 id="tail"><a href="#tail" class="fa fa-link"></a><code>_.tail(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8139">source</a> <a href="https://www.npmjs.com/package/lodash.tail">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8203">source</a> <a href="https://www.npmjs.com/package/lodash.tail">npm package</a></p>
 <p>Gets all but the first element of <code>array</code>.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -1251,7 +1251,7 @@ for sorted arrays.</p>
 </div>
 <div>
 <h3 id="take"><a href="#take" class="fa fa-link"></a><code>_.take(array, [n=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8169">source</a> <a href="https://www.npmjs.com/package/lodash.take">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8233">source</a> <a href="https://www.npmjs.com/package/lodash.take">npm package</a></p>
 <p>Creates a slice of <code>array</code> with <code>n</code> elements taken from the beginning.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -1268,7 +1268,7 @@ for sorted arrays.</p>
 </div>
 <div>
 <h3 id="takeRight"><a href="#takeRight" class="fa fa-link"></a><code>_.takeRight(array, [n=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8202">source</a> <a href="https://www.npmjs.com/package/lodash.takeright">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8266">source</a> <a href="https://www.npmjs.com/package/lodash.takeright">npm package</a></p>
 <p>Creates a slice of <code>array</code> with <code>n</code> elements taken from the end.</p>
 <h4>Since</h4>
 <p>3.0.0</p>
@@ -1285,7 +1285,7 @@ for sorted arrays.</p>
 </div>
 <div>
 <h3 id="takeRightWhile"><a href="#takeRightWhile" class="fa fa-link"></a><code>_.takeRightWhile(array, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8247">source</a> <a href="https://www.npmjs.com/package/lodash.takerightwhile">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8311">source</a> <a href="https://www.npmjs.com/package/lodash.takerightwhile">npm package</a></p>
 <p>Creates a slice of <code>array</code> with elements taken from the end. Elements are
 taken until <code>predicate</code> returns falsey. The predicate is invoked with
 three arguments: <em>(value, index, array)</em>.</p>
@@ -1304,7 +1304,7 @@ three arguments: <em>(value, index, array)</em>.</p>
 </div>
 <div>
 <h3 id="takeWhile"><a href="#takeWhile" class="fa fa-link"></a><code>_.takeWhile(array, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8288">source</a> <a href="https://www.npmjs.com/package/lodash.takewhile">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8352">source</a> <a href="https://www.npmjs.com/package/lodash.takewhile">npm package</a></p>
 <p>Creates a slice of <code>array</code> with elements taken from the beginning. Elements
 are taken until <code>predicate</code> returns falsey. The predicate is invoked with
 three arguments: <em>(value, index, array)</em>.</p>
@@ -1323,7 +1323,7 @@ three arguments: <em>(value, index, array)</em>.</p>
 </div>
 <div>
 <h3 id="union"><a href="#union" class="fa fa-link"></a><code>_.union([arrays])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8310">source</a> <a href="https://www.npmjs.com/package/lodash.union">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8374">source</a> <a href="https://www.npmjs.com/package/lodash.union">npm package</a></p>
 <p>Creates an array of unique values, in order, from all given arrays using
 <a href="http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero"><code>SameValueZero</code></a>
 for equality comparisons.</p>
@@ -1341,7 +1341,7 @@ for equality comparisons.</p>
 </div>
 <div>
 <h3 id="unionBy"><a href="#unionBy" class="fa fa-link"></a><code>_.unionBy([arrays], [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8337">source</a> <a href="https://www.npmjs.com/package/lodash.unionby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8401">source</a> <a href="https://www.npmjs.com/package/lodash.unionby">npm package</a></p>
 <p>This method is like <a href="#union"><code>_.union</code></a> except that it accepts <code>iteratee</code> which is
 invoked for each element of each <code>arrays</code> to generate the criterion by
 which uniqueness is computed. Result values are chosen from the first
@@ -1362,7 +1362,7 @@ array in which the value occurs. The iteratee is invoked with one argument:<br>
 </div>
 <div>
 <h3 id="unionWith"><a href="#unionWith" class="fa fa-link"></a><code>_.unionWith([arrays], [comparator])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8366">source</a> <a href="https://www.npmjs.com/package/lodash.unionwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8430">source</a> <a href="https://www.npmjs.com/package/lodash.unionwith">npm package</a></p>
 <p>This method is like <a href="#union"><code>_.union</code></a> except that it accepts <code>comparator</code> which
 is invoked to compare elements of <code>arrays</code>. Result values are chosen from
 the first array in which the value occurs. The comparator is invoked
@@ -1382,7 +1382,7 @@ with two arguments: <em>(arrVal, othVal)</em>.</p>
 </div>
 <div>
 <h3 id="uniq"><a href="#uniq" class="fa fa-link"></a><code>_.uniq(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8390">source</a> <a href="https://www.npmjs.com/package/lodash.uniq">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8454">source</a> <a href="https://www.npmjs.com/package/lodash.uniq">npm package</a></p>
 <p>Creates a duplicate-free version of an array, using
 <a href="http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero"><code>SameValueZero</code></a>
 for equality comparisons, in which only the first occurrence of each element
@@ -1402,7 +1402,7 @@ in the array.</p>
 </div>
 <div>
 <h3 id="uniqBy"><a href="#uniqBy" class="fa fa-link"></a><code>_.uniqBy(array, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8417">source</a> <a href="https://www.npmjs.com/package/lodash.uniqby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8481">source</a> <a href="https://www.npmjs.com/package/lodash.uniqby">npm package</a></p>
 <p>This method is like <a href="#uniq"><code>_.uniq</code></a> except that it accepts <code>iteratee</code> which is
 invoked for each element in <code>array</code> to generate the criterion by which
 uniqueness is computed. The order of result values is determined by the
@@ -1423,7 +1423,7 @@ order they occur in the array. The iteratee is invoked with one argument:<br>
 </div>
 <div>
 <h3 id="uniqWith"><a href="#uniqWith" class="fa fa-link"></a><code>_.uniqWith(array, [comparator])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8441">source</a> <a href="https://www.npmjs.com/package/lodash.uniqwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8505">source</a> <a href="https://www.npmjs.com/package/lodash.uniqwith">npm package</a></p>
 <p>This method is like <a href="#uniq"><code>_.uniq</code></a> except that it accepts <code>comparator</code> which
 is invoked to compare elements of <code>array</code>. The order of result values is
 determined by the order they occur in the array.The comparator is invoked
@@ -1443,7 +1443,7 @@ with two arguments: <em>(arrVal, othVal)</em>.</p>
 </div>
 <div>
 <h3 id="unzip"><a href="#unzip" class="fa fa-link"></a><code>_.unzip(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8465">source</a> <a href="https://www.npmjs.com/package/lodash.unzip">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8529">source</a> <a href="https://www.npmjs.com/package/lodash.unzip">npm package</a></p>
 <p>This method is like <a href="#zip"><code>_.zip</code></a> except that it accepts an array of grouped
 elements and creates an array regrouping the elements to their pre-zip
 configuration.</p>
@@ -1461,7 +1461,7 @@ configuration.</p>
 </div>
 <div>
 <h3 id="unzipWith"><a href="#unzipWith" class="fa fa-link"></a><code>_.unzipWith(array, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8502">source</a> <a href="https://www.npmjs.com/package/lodash.unzipwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8566">source</a> <a href="https://www.npmjs.com/package/lodash.unzipwith">npm package</a></p>
 <p>This method is like <a href="#unzip"><code>_.unzip</code></a> except that it accepts <code>iteratee</code> to specify
 how regrouped values should be combined. The iteratee is invoked with the
 elements of each group: <em>(...group)</em>.</p>
@@ -1480,7 +1480,7 @@ elements of each group: <em>(...group)</em>.</p>
 </div>
 <div>
 <h3 id="without"><a href="#without" class="fa fa-link"></a><code>_.without(array, [values])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8535">source</a> <a href="https://www.npmjs.com/package/lodash.without">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8599">source</a> <a href="https://www.npmjs.com/package/lodash.without">npm package</a></p>
 <p>Creates an array excluding all given values using
 <a href="http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero"><code>SameValueZero</code></a>
 for equality comparisons.
@@ -1502,7 +1502,7 @@ for equality comparisons.
 </div>
 <div>
 <h3 id="xor"><a href="#xor" class="fa fa-link"></a><code>_.xor([arrays])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8559">source</a> <a href="https://www.npmjs.com/package/lodash.xor">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8623">source</a> <a href="https://www.npmjs.com/package/lodash.xor">npm package</a></p>
 <p>Creates an array of unique values that is the
 <a href="https://en.wikipedia.org/wiki/Symmetric_difference">symmetric difference</a>
 of the given arrays. The order of result values is determined by the order
@@ -1521,7 +1521,7 @@ they occur in the arrays.</p>
 </div>
 <div>
 <h3 id="xorBy"><a href="#xorBy" class="fa fa-link"></a><code>_.xorBy([arrays], [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8586">source</a> <a href="https://www.npmjs.com/package/lodash.xorby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8650">source</a> <a href="https://www.npmjs.com/package/lodash.xorby">npm package</a></p>
 <p>This method is like <a href="#xor"><code>_.xor</code></a> except that it accepts <code>iteratee</code> which is
 invoked for each element of each <code>arrays</code> to generate the criterion by
 which by which they&apos;re compared. The order of result values is determined
@@ -1542,7 +1542,7 @@ argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="xorWith"><a href="#xorWith" class="fa fa-link"></a><code>_.xorWith([arrays], [comparator])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8615">source</a> <a href="https://www.npmjs.com/package/lodash.xorwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8679">source</a> <a href="https://www.npmjs.com/package/lodash.xorwith">npm package</a></p>
 <p>This method is like <a href="#xor"><code>_.xor</code></a> except that it accepts <code>comparator</code> which is
 invoked to compare elements of <code>arrays</code>. The order of result values is
 determined by the order they occur in the arrays. The comparator is invoked
@@ -1562,7 +1562,7 @@ with two arguments: <em>(arrVal, othVal)</em>.</p>
 </div>
 <div>
 <h3 id="zip"><a href="#zip" class="fa fa-link"></a><code>_.zip([arrays])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8637">source</a> <a href="https://www.npmjs.com/package/lodash.zip">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8701">source</a> <a href="https://www.npmjs.com/package/lodash.zip">npm package</a></p>
 <p>Creates an array of grouped elements, the first of which contains the
 first elements of the given arrays, the second of which contains the
 second elements of the given arrays, and so on.</p>
@@ -1580,7 +1580,7 @@ second elements of the given arrays, and so on.</p>
 </div>
 <div>
 <h3 id="zipObject"><a href="#zipObject" class="fa fa-link"></a><code>_.zipObject([props=[]], [values=[]])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8655">source</a> <a href="https://www.npmjs.com/package/lodash.zipobject">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8719">source</a> <a href="https://www.npmjs.com/package/lodash.zipobject">npm package</a></p>
 <p>This method is like <a href="#fromPairs"><code>_.fromPairs</code></a> except that it accepts two arrays,
 one of property identifiers and one of corresponding values.</p>
 <h4>Since</h4>
@@ -1598,7 +1598,7 @@ one of property identifiers and one of corresponding values.</p>
 </div>
 <div>
 <h3 id="zipObjectDeep"><a href="#zipObjectDeep" class="fa fa-link"></a><code>_.zipObjectDeep([props=[]], [values=[]])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8674">source</a> <a href="https://www.npmjs.com/package/lodash.zipobjectdeep">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8738">source</a> <a href="https://www.npmjs.com/package/lodash.zipobjectdeep">npm package</a></p>
 <p>This method is like <a href="#zipObject"><code>_.zipObject</code></a> except that it supports property paths.</p>
 <h4>Since</h4>
 <p>4.1.0</p>
@@ -1615,7 +1615,7 @@ one of property identifiers and one of corresponding values.</p>
 </div>
 <div>
 <h3 id="zipWith"><a href="#zipWith" class="fa fa-link"></a><code>_.zipWith([arrays], [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8698">source</a> <a href="https://www.npmjs.com/package/lodash.zipwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8762">source</a> <a href="https://www.npmjs.com/package/lodash.zipwith">npm package</a></p>
 <p>This method is like <a href="#zip"><code>_.zip</code></a> except that it accepts <code>iteratee</code> to specify
 how grouped values should be combined. The iteratee is invoked with the
 elements of each group: <em>(...group)</em>.</p>
@@ -1637,7 +1637,7 @@ elements of each group: <em>(...group)</em>.</p>
 <h2><code>&#x201C;Collection&#x201D; Methods</code></h2>
 <div>
 <h3 id="countBy"><a href="#countBy" class="fa fa-link"></a><code>_.countBy(collection, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9077">source</a> <a href="https://www.npmjs.com/package/lodash.countby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9141">source</a> <a href="https://www.npmjs.com/package/lodash.countby">npm package</a></p>
 <p>Creates an object composed of keys generated from the results of running
 each element of <code>collection</code> thru <code>iteratee</code>. The corresponding value of
 each key is the number of times the key was returned by <code>iteratee</code>. The
@@ -1657,7 +1657,7 @@ iteratee is invoked with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="every"><a href="#every" class="fa fa-link"></a><code>_.every(collection, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9126">source</a> <a href="https://www.npmjs.com/package/lodash.every">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9190">source</a> <a href="https://www.npmjs.com/package/lodash.every">npm package</a></p>
 <p>Checks if <code>predicate</code> returns truthy for <strong>all</strong> elements of <code>collection</code>.
 Iteration is stopped once <code>predicate</code> returns falsey. The predicate is
 invoked with three arguments: <em>(value, index|key, collection)</em>.
@@ -1682,7 +1682,7 @@ elements of empty collections.</p>
 </div>
 <div>
 <h3 id="filter"><a href="#filter" class="fa fa-link"></a><code>_.filter(collection, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9171">source</a> <a href="https://www.npmjs.com/package/lodash.filter">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9239">source</a> <a href="https://www.npmjs.com/package/lodash.filter">npm package</a></p>
 <p>Iterates over elements of <code>collection</code>, returning an array of all elements
 <code>predicate</code> returns truthy for. The predicate is invoked with three
 arguments: <em>(value, index|key, collection)</em>.
@@ -1699,12 +1699,12 @@ arguments: <em>(value, index|key, collection)</em>.
 <h4>Returns</h4>
 <p><em>(Array)</em>: Returns the new filtered array.</p>
 <h4>Example</h4>
-<div class="highlight js"><pre><div><span class="type">var</span>&#xA0;users&#xA0;=&#xA0;[</div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;barney&apos;</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">36</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;active&apos;</span>:&#xA0;true&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;fred&apos;</span><span class="delimiter">,</span>&#xA0;&#xA0;&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">40</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;active&apos;</span>:&#xA0;false&#xA0;}</div><div>];</div><div>&#xA0;</div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(users<span class="delimiter">,</span>&#xA0;<span class="type">function</span>(o)&#xA0;{&#xA0;return&#xA0;!o<span class="delimiter">.</span>active;&#xA0;});</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[&apos;fred&apos;]</span></div><div>&#xA0;</div><div><span class="comment">//&#xA0;The&#xA0;`_.matches`&#xA0;iteratee&#xA0;shorthand.</span></div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(users<span class="delimiter">,</span>&#xA0;{&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">36</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;active&apos;</span>:&#xA0;true&#xA0;});</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[&apos;barney&apos;]</span></div><div>&#xA0;</div><div><span class="comment">//&#xA0;The&#xA0;`_.matchesProperty`&#xA0;iteratee&#xA0;shorthand.</span></div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(users<span class="delimiter">,</span>&#xA0;[<span class="string">&apos;active&apos;</span><span class="delimiter">,</span>&#xA0;false]);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[&apos;fred&apos;]</span></div><div>&#xA0;</div><div><span class="comment">//&#xA0;The&#xA0;`_.property`&#xA0;iteratee&#xA0;shorthand.</span></div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(users<span class="delimiter">,</span>&#xA0;<span class="string">&apos;active&apos;</span>);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[&apos;barney&apos;]</span></div></pre></div>
+<div class="highlight js"><pre><div><span class="type">var</span>&#xA0;users&#xA0;=&#xA0;[</div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;barney&apos;</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">36</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;active&apos;</span>:&#xA0;true&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;fred&apos;</span><span class="delimiter">,</span>&#xA0;&#xA0;&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">40</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;active&apos;</span>:&#xA0;false&#xA0;}</div><div>];</div><div>&#xA0;</div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(users<span class="delimiter">,</span>&#xA0;<span class="type">function</span>(o)&#xA0;{&#xA0;return&#xA0;!o<span class="delimiter">.</span>active;&#xA0;});</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[&apos;fred&apos;]</span></div><div>&#xA0;</div><div><span class="comment">//&#xA0;The&#xA0;`_.matches`&#xA0;iteratee&#xA0;shorthand.</span></div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(users<span class="delimiter">,</span>&#xA0;{&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">36</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;active&apos;</span>:&#xA0;true&#xA0;});</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[&apos;barney&apos;]</span></div><div>&#xA0;</div><div><span class="comment">//&#xA0;The&#xA0;`_.matchesProperty`&#xA0;iteratee&#xA0;shorthand.</span></div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(users<span class="delimiter">,</span>&#xA0;[<span class="string">&apos;active&apos;</span><span class="delimiter">,</span>&#xA0;false]);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[&apos;fred&apos;]</span></div><div>&#xA0;</div><div><span class="comment">//&#xA0;The&#xA0;`_.property`&#xA0;iteratee&#xA0;shorthand.</span></div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(users<span class="delimiter">,</span>&#xA0;<span class="string">&apos;active&apos;</span>);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[&apos;barney&apos;]</span></div><div>&#xA0;</div><div><span class="comment">//&#xA0;Combining&#xA0;several&#xA0;predicates&#xA0;using&#xA0;`_.overEvery`&#xA0;or&#xA0;`_.overSome`.</span></div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(users<span class="delimiter">,</span>&#xA0;_<span class="delimiter method">.</span><span class="name">overSome</span>([{&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">36</span>&#xA0;}<span class="delimiter">,</span>&#xA0;[<span class="string">&apos;age&apos;</span><span class="delimiter">,</span>&#xA0;<span class="numeric">40</span>]]));</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[&apos;fred&apos;,&#xA0;&apos;barney&apos;]</span></div></pre></div>
 
 </div>
 <div>
 <h3 id="find"><a href="#find" class="fa fa-link"></a><code>_.find(collection, [predicate=_.identity], [fromIndex=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9212">source</a> <a href="https://www.npmjs.com/package/lodash.find">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9280">source</a> <a href="https://www.npmjs.com/package/lodash.find">npm package</a></p>
 <p>Iterates over elements of <code>collection</code>, returning the first element
 <code>predicate</code> returns truthy for. The predicate is invoked with three
 arguments: <em>(value, index|key, collection)</em>.</p>
@@ -1724,7 +1724,7 @@ arguments: <em>(value, index|key, collection)</em>.</p>
 </div>
 <div>
 <h3 id="findLast"><a href="#findLast" class="fa fa-link"></a><code>_.findLast(collection, [predicate=_.identity], [fromIndex=collection.length-1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9233">source</a> <a href="https://www.npmjs.com/package/lodash.findlast">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9301">source</a> <a href="https://www.npmjs.com/package/lodash.findlast">npm package</a></p>
 <p>This method is like <a href="#find"><code>_.find</code></a> except that it iterates over elements of
 <code>collection</code> from right to left.</p>
 <h4>Since</h4>
@@ -1743,7 +1743,7 @@ arguments: <em>(value, index|key, collection)</em>.</p>
 </div>
 <div>
 <h3 id="flatMap"><a href="#flatMap" class="fa fa-link"></a><code>_.flatMap(collection, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9256">source</a> <a href="https://www.npmjs.com/package/lodash.flatmap">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9324">source</a> <a href="https://www.npmjs.com/package/lodash.flatmap">npm package</a></p>
 <p>Creates a flattened array of values by running each element in <code>collection</code>
 thru <code>iteratee</code> and flattening the mapped results. The iteratee is invoked
 with three arguments: <em>(value, index|key, collection)</em>.</p>
@@ -1762,7 +1762,7 @@ with three arguments: <em>(value, index|key, collection)</em>.</p>
 </div>
 <div>
 <h3 id="flatMapDeep"><a href="#flatMapDeep" class="fa fa-link"></a><code>_.flatMapDeep(collection, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9280">source</a> <a href="https://www.npmjs.com/package/lodash.flatmapdeep">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9348">source</a> <a href="https://www.npmjs.com/package/lodash.flatmapdeep">npm package</a></p>
 <p>This method is like <a href="#flatMap"><code>_.flatMap</code></a> except that it recursively flattens the
 mapped results.</p>
 <h4>Since</h4>
@@ -1780,7 +1780,7 @@ mapped results.</p>
 </div>
 <div>
 <h3 id="flatMapDepth"><a href="#flatMapDepth" class="fa fa-link"></a><code>_.flatMapDepth(collection, [iteratee=_.identity], [depth=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9305">source</a> <a href="https://www.npmjs.com/package/lodash.flatmapdepth">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9373">source</a> <a href="https://www.npmjs.com/package/lodash.flatmapdepth">npm package</a></p>
 <p>This method is like <a href="#flatMap"><code>_.flatMap</code></a> except that it recursively flattens the
 mapped results up to <code>depth</code> times.</p>
 <h4>Since</h4>
@@ -1799,7 +1799,7 @@ mapped results up to <code>depth</code> times.</p>
 </div>
 <div>
 <h3 id="forEach"><a href="#forEach" class="fa fa-link"></a><code>_.forEach(collection, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9340">source</a> <a href="https://www.npmjs.com/package/lodash.foreach">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9408">source</a> <a href="https://www.npmjs.com/package/lodash.foreach">npm package</a></p>
 <p>Iterates over elements of <code>collection</code> and invokes <code>iteratee</code> for each element.
 The iteratee is invoked with three arguments: <em>(value, index|key, collection)</em>.
 Iteratee functions may exit iteration early by explicitly returning <code>false</code>.
@@ -1825,7 +1825,7 @@ or <a href="#forOwn"><code>_.forOwn</code></a> for object iteration.</p>
 </div>
 <div>
 <h3 id="forEachRight"><a href="#forEachRight" class="fa fa-link"></a><code>_.forEachRight(collection, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9365">source</a> <a href="https://www.npmjs.com/package/lodash.foreachright">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9433">source</a> <a href="https://www.npmjs.com/package/lodash.foreachright">npm package</a></p>
 <p>This method is like <a href="#forEach"><code>_.forEach</code></a> except that it iterates over elements of
 <code>collection</code> from right to left.</p>
 <h4>Since</h4>
@@ -1845,7 +1845,7 @@ or <a href="#forOwn"><code>_.forOwn</code></a> for object iteration.</p>
 </div>
 <div>
 <h3 id="groupBy"><a href="#groupBy" class="fa fa-link"></a><code>_.groupBy(collection, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9393">source</a> <a href="https://www.npmjs.com/package/lodash.groupby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9461">source</a> <a href="https://www.npmjs.com/package/lodash.groupby">npm package</a></p>
 <p>Creates an object composed of keys generated from the results of running
 each element of <code>collection</code> thru <code>iteratee</code>. The order of grouped values
 is determined by the order they occur in <code>collection</code>. The corresponding
@@ -1866,7 +1866,7 @@ key. The iteratee is invoked with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="includes"><a href="#includes" class="fa fa-link"></a><code>_.includes(collection, value, [fromIndex=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9431">source</a> <a href="https://www.npmjs.com/package/lodash.includes">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9499">source</a> <a href="https://www.npmjs.com/package/lodash.includes">npm package</a></p>
 <p>Checks if <code>value</code> is in <code>collection</code>. If <code>collection</code> is a string, it&apos;s
 checked for a substring of <code>value</code>, otherwise
 <a href="http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero"><code>SameValueZero</code></a>
@@ -1888,7 +1888,7 @@ the offset from the end of <code>collection</code>.</p>
 </div>
 <div>
 <h3 id="invokeMap"><a href="#invokeMap" class="fa fa-link"></a><code>_.invokeMap(collection, path, [args])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9467">source</a> <a href="https://www.npmjs.com/package/lodash.invokemap">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9535">source</a> <a href="https://www.npmjs.com/package/lodash.invokemap">npm package</a></p>
 <p>Invokes the method at <code>path</code> of each element in <code>collection</code>, returning
 an array of the results of each invoked method. Any additional arguments
 are provided to each invoked method. If <code>path</code> is a function, it&apos;s invoked
@@ -1909,7 +1909,7 @@ for, and <code>this</code> bound to, each element in <code>collection</code>.</p
 </div>
 <div>
 <h3 id="keyBy"><a href="#keyBy" class="fa fa-link"></a><code>_.keyBy(collection, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9506">source</a> <a href="https://www.npmjs.com/package/lodash.keyby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9574">source</a> <a href="https://www.npmjs.com/package/lodash.keyby">npm package</a></p>
 <p>Creates an object composed of keys generated from the results of running
 each element of <code>collection</code> thru <code>iteratee</code>. The corresponding value of
 each key is the last element responsible for generating the key. The
@@ -1929,7 +1929,7 @@ iteratee is invoked with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="map"><a href="#map" class="fa fa-link"></a><code>_.map(collection, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9552">source</a> <a href="https://www.npmjs.com/package/lodash.map">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9620">source</a> <a href="https://www.npmjs.com/package/lodash.map">npm package</a></p>
 <p>Creates an array of values by running each element in <code>collection</code> thru
 <code>iteratee</code>. The iteratee is invoked with three arguments:<br>
 <em>(value, index|key, collection)</em>.
@@ -1959,7 +1959,7 @@ The guarded methods are:<br>
 </div>
 <div>
 <h3 id="orderBy"><a href="#orderBy" class="fa fa-link"></a><code>_.orderBy(collection, [iteratees=[_.identity]], [orders])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9586">source</a> <a href="https://www.npmjs.com/package/lodash.orderby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9654">source</a> <a href="https://www.npmjs.com/package/lodash.orderby">npm package</a></p>
 <p>This method is like <a href="#sortBy"><code>_.sortBy</code></a> except that it allows specifying the sort
 orders of the iteratees to sort by. If <code>orders</code> is unspecified, all values
 are sorted in ascending order. Otherwise, specify an order of &quot;desc&quot; for
@@ -1980,7 +1980,7 @@ descending or &quot;asc&quot; for ascending sort order of corresponding values.<
 </div>
 <div>
 <h3 id="partition"><a href="#partition" class="fa fa-link"></a><code>_.partition(collection, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9636">source</a> <a href="https://www.npmjs.com/package/lodash.partition">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9704">source</a> <a href="https://www.npmjs.com/package/lodash.partition">npm package</a></p>
 <p>Creates an array of elements split into two groups, the first of which
 contains elements <code>predicate</code> returns truthy for, the second of which
 contains elements <code>predicate</code> returns falsey for. The predicate is
@@ -2000,7 +2000,7 @@ invoked with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="reduce"><a href="#reduce" class="fa fa-link"></a><code>_.reduce(collection, [iteratee=_.identity], [accumulator])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9677">source</a> <a href="https://www.npmjs.com/package/lodash.reduce">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9745">source</a> <a href="https://www.npmjs.com/package/lodash.reduce">npm package</a></p>
 <p>Reduces <code>collection</code> to a value which is the accumulated result of running
 each element in <code>collection</code> thru <code>iteratee</code>, where each successive
 invocation is supplied the return value of the previous. If <code>accumulator</code>
@@ -2032,7 +2032,7 @@ and <code>sortBy</code></p>
 </div>
 <div>
 <h3 id="reduceRight"><a href="#reduceRight" class="fa fa-link"></a><code>_.reduceRight(collection, [iteratee=_.identity], [accumulator])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9706">source</a> <a href="https://www.npmjs.com/package/lodash.reduceright">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9774">source</a> <a href="https://www.npmjs.com/package/lodash.reduceright">npm package</a></p>
 <p>This method is like <a href="#reduce"><code>_.reduce</code></a> except that it iterates over elements of
 <code>collection</code> from right to left.</p>
 <h4>Since</h4>
@@ -2051,7 +2051,7 @@ and <code>sortBy</code></p>
 </div>
 <div>
 <h3 id="reject"><a href="#reject" class="fa fa-link"></a><code>_.reject(collection, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9747">source</a> <a href="https://www.npmjs.com/package/lodash.reject">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9815">source</a> <a href="https://www.npmjs.com/package/lodash.reject">npm package</a></p>
 <p>The opposite of <a href="#filter"><code>_.filter</code></a>; this method returns the elements of <code>collection</code>
 that <code>predicate</code> does <strong>not</strong> return truthy for.</p>
 <h4>Since</h4>
@@ -2069,7 +2069,7 @@ that <code>predicate</code> does <strong>not</strong> return truthy for.</p>
 </div>
 <div>
 <h3 id="sample"><a href="#sample" class="fa fa-link"></a><code>_.sample(collection)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9766">source</a> <a href="https://www.npmjs.com/package/lodash.sample">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9834">source</a> <a href="https://www.npmjs.com/package/lodash.sample">npm package</a></p>
 <p>Gets a random element from <code>collection</code>.</p>
 <h4>Since</h4>
 <p>2.0.0</p>
@@ -2085,7 +2085,7 @@ that <code>predicate</code> does <strong>not</strong> return truthy for.</p>
 </div>
 <div>
 <h3 id="sampleSize"><a href="#sampleSize" class="fa fa-link"></a><code>_.sampleSize(collection, [n=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9791">source</a> <a href="https://www.npmjs.com/package/lodash.samplesize">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9859">source</a> <a href="https://www.npmjs.com/package/lodash.samplesize">npm package</a></p>
 <p>Gets <code>n</code> random elements at unique keys from <code>collection</code> up to the
 size of <code>collection</code>.</p>
 <h4>Since</h4>
@@ -2103,7 +2103,7 @@ size of <code>collection</code>.</p>
 </div>
 <div>
 <h3 id="shuffle"><a href="#shuffle" class="fa fa-link"></a><code>_.shuffle(collection)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9816">source</a> <a href="https://www.npmjs.com/package/lodash.shuffle">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9884">source</a> <a href="https://www.npmjs.com/package/lodash.shuffle">npm package</a></p>
 <p>Creates an array of shuffled values, using a version of the
 <a href="https://en.wikipedia.org/wiki/Fisher-Yates_shuffle">Fisher-Yates shuffle</a>.</p>
 <h4>Since</h4>
@@ -2120,7 +2120,7 @@ size of <code>collection</code>.</p>
 </div>
 <div>
 <h3 id="size"><a href="#size" class="fa fa-link"></a><code>_.size(collection)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9842">source</a> <a href="https://www.npmjs.com/package/lodash.size">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9910">source</a> <a href="https://www.npmjs.com/package/lodash.size">npm package</a></p>
 <p>Gets the size of <code>collection</code> by returning its length for array-like
 values or the number of own enumerable string keyed properties for objects.</p>
 <h4>Since</h4>
@@ -2137,7 +2137,7 @@ values or the number of own enumerable string keyed properties for objects.</p>
 </div>
 <div>
 <h3 id="some"><a href="#some" class="fa fa-link"></a><code>_.some(collection, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9892">source</a> <a href="https://www.npmjs.com/package/lodash.some">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9960">source</a> <a href="https://www.npmjs.com/package/lodash.some">npm package</a></p>
 <p>Checks if <code>predicate</code> returns truthy for <strong>any</strong> element of <code>collection</code>.
 Iteration is stopped once <code>predicate</code> returns truthy. The predicate is
 invoked with three arguments: <em>(value, index|key, collection)</em>.</p>
@@ -2156,7 +2156,7 @@ invoked with three arguments: <em>(value, index|key, collection)</em>.</p>
 </div>
 <div>
 <h3 id="sortBy"><a href="#sortBy" class="fa fa-link"></a><code>_.sortBy(collection, [iteratees=[_.identity]])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9929">source</a> <a href="https://www.npmjs.com/package/lodash.sortby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9997">source</a> <a href="https://www.npmjs.com/package/lodash.sortby">npm package</a></p>
 <p>Creates an array of elements, sorted in ascending order by the results of
 running each element in a collection thru each iteratee. This method
 performs a stable sort, that is, it preserves the original sort order of
@@ -2171,7 +2171,7 @@ equal elements. The iteratees are invoked with one argument: <em>(value)</em>.</
 <h4>Returns</h4>
 <p><em>(Array)</em>: Returns the new sorted array.</p>
 <h4>Example</h4>
-<div class="highlight js"><pre><div><span class="type">var</span>&#xA0;users&#xA0;=&#xA0;[</div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;fred&apos;</span><span class="delimiter">,</span>&#xA0;&#xA0;&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">48</span>&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;barney&apos;</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">36</span>&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;fred&apos;</span><span class="delimiter">,</span>&#xA0;&#xA0;&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">40</span>&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;barney&apos;</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">34</span>&#xA0;}</div><div>];</div><div>&#xA0;</div><div>_<span class="delimiter method">.</span><span class="name">sortBy</span>(users<span class="delimiter">,</span>&#xA0;[<span class="type">function</span>(o)&#xA0;{&#xA0;return&#xA0;o<span class="delimiter">.</span>user;&#xA0;}]);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[[&apos;barney&apos;,&#xA0;36],&#xA0;[&apos;barney&apos;,&#xA0;34],&#xA0;[&apos;fred&apos;,&#xA0;48],&#xA0;[&apos;fred&apos;,&#xA0;40]]</span></div><div>&#xA0;</div><div>_<span class="delimiter method">.</span><span class="name">sortBy</span>(users<span class="delimiter">,</span>&#xA0;[<span class="string">&apos;user&apos;</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;age&apos;</span>]);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[[&apos;barney&apos;,&#xA0;34],&#xA0;[&apos;barney&apos;,&#xA0;36],&#xA0;[&apos;fred&apos;,&#xA0;40],&#xA0;[&apos;fred&apos;,&#xA0;48]]</span></div></pre></div>
+<div class="highlight js"><pre><div><span class="type">var</span>&#xA0;users&#xA0;=&#xA0;[</div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;fred&apos;</span><span class="delimiter">,</span>&#xA0;&#xA0;&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">48</span>&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;barney&apos;</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">36</span>&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;fred&apos;</span><span class="delimiter">,</span>&#xA0;&#xA0;&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">30</span>&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;user&apos;</span>:&#xA0;<span class="string">&apos;barney&apos;</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;age&apos;</span>:&#xA0;<span class="numeric">34</span>&#xA0;}</div><div>];</div><div>&#xA0;</div><div>_<span class="delimiter method">.</span><span class="name">sortBy</span>(users<span class="delimiter">,</span>&#xA0;[<span class="type">function</span>(o)&#xA0;{&#xA0;return&#xA0;o<span class="delimiter">.</span>user;&#xA0;}]);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[[&apos;barney&apos;,&#xA0;36],&#xA0;[&apos;barney&apos;,&#xA0;34],&#xA0;[&apos;fred&apos;,&#xA0;48],&#xA0;[&apos;fred&apos;,&#xA0;30]]</span></div><div>&#xA0;</div><div>_<span class="delimiter method">.</span><span class="name">sortBy</span>(users<span class="delimiter">,</span>&#xA0;[<span class="string">&apos;user&apos;</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;age&apos;</span>]);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;objects&#xA0;for&#xA0;[[&apos;barney&apos;,&#xA0;34],&#xA0;[&apos;barney&apos;,&#xA0;36],&#xA0;[&apos;fred&apos;,&#xA0;30],&#xA0;[&apos;fred&apos;,&#xA0;48]]</span></div></pre></div>
 
 </div>
 </div>
@@ -2179,7 +2179,7 @@ equal elements. The iteratees are invoked with one argument: <em>(value)</em>.</
 <h2><code>&#x201C;Date&#x201D; Methods</code></h2>
 <div>
 <h3 id="now"><a href="#now" class="fa fa-link"></a><code>_.now()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9960">source</a> <a href="https://www.npmjs.com/package/lodash.now">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10028">source</a> <a href="https://www.npmjs.com/package/lodash.now">npm package</a></p>
 <p>Gets the timestamp of the number of milliseconds that have elapsed since
 the Unix epoch <em>(1 January <code>1970 00</code>:00:00 UTC)</em>.</p>
 <h4>Since</h4>
@@ -2195,7 +2195,7 @@ the Unix epoch <em>(1 January <code>1970 00</code>:00:00 UTC)</em>.</p>
 <h2><code>&#x201C;Function&#x201D; Methods</code></h2>
 <div>
 <h3 id="after"><a href="#after" class="fa fa-link"></a><code>_.after(n, func)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9990">source</a> <a href="https://www.npmjs.com/package/lodash.after">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10058">source</a> <a href="https://www.npmjs.com/package/lodash.after">npm package</a></p>
 <p>The opposite of <a href="#before"><code>_.before</code></a>; this method creates a function that invokes
 <code>func</code> once it&apos;s called <code>n</code> or more times.</p>
 <h4>Since</h4>
@@ -2213,7 +2213,7 @@ the Unix epoch <em>(1 January <code>1970 00</code>:00:00 UTC)</em>.</p>
 </div>
 <div>
 <h3 id="ary"><a href="#ary" class="fa fa-link"></a><code>_.ary(func, [n=func.length])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10019">source</a> <a href="https://www.npmjs.com/package/lodash.ary">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10087">source</a> <a href="https://www.npmjs.com/package/lodash.ary">npm package</a></p>
 <p>Creates a function that invokes <code>func</code>, with up to <code>n</code> arguments,
 ignoring any additional arguments.</p>
 <h4>Since</h4>
@@ -2231,7 +2231,7 @@ ignoring any additional arguments.</p>
 </div>
 <div>
 <h3 id="before"><a href="#before" class="fa fa-link"></a><code>_.before(n, func)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10042">source</a> <a href="https://www.npmjs.com/package/lodash.before">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10110">source</a> <a href="https://www.npmjs.com/package/lodash.before">npm package</a></p>
 <p>Creates a function that invokes <code>func</code>, with the <code>this</code> binding and arguments
 of the created function, while it&apos;s called less than <code>n</code> times. Subsequent
 calls to the created function return the result of the last <code>func</code> invocation.</p>
@@ -2250,7 +2250,7 @@ calls to the created function return the result of the last <code>func</code> in
 </div>
 <div>
 <h3 id="bind"><a href="#bind" class="fa fa-link"></a><code>_.bind(func, thisArg, [partials])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10094">source</a> <a href="https://www.npmjs.com/package/lodash.bind">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10162">source</a> <a href="https://www.npmjs.com/package/lodash.bind">npm package</a></p>
 <p>Creates a function that invokes <code>func</code> with the <code>this</code> binding of <code>thisArg</code>
 and <code>partials</code> prepended to the arguments it receives.
 <br>
@@ -2277,7 +2277,7 @@ property of bound functions.</p>
 </div>
 <div>
 <h3 id="bindKey"><a href="#bindKey" class="fa fa-link"></a><code>_.bindKey(object, key, [partials])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10148">source</a> <a href="https://www.npmjs.com/package/lodash.bindkey">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10216">source</a> <a href="https://www.npmjs.com/package/lodash.bindkey">npm package</a></p>
 <p>Creates a function that invokes the method at <code>object[key]</code> with <code>partials</code>
 prepended to the arguments it receives.
 <br>
@@ -2306,7 +2306,7 @@ builds, may be used as a placeholder for partially applied arguments.</p>
 </div>
 <div>
 <h3 id="curry"><a href="#curry" class="fa fa-link"></a><code>_.curry(func, [arity=func.length])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10198">source</a> <a href="https://www.npmjs.com/package/lodash.curry">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10266">source</a> <a href="https://www.npmjs.com/package/lodash.curry">npm package</a></p>
 <p>Creates a function that accepts arguments of <code>func</code> and either invokes
 <code>func</code> returning its result, if at least <code>arity</code> number of arguments have
 been provided, or returns a function that accepts the remaining <code>func</code>
@@ -2334,7 +2334,7 @@ may be used as a placeholder for provided arguments.
 </div>
 <div>
 <h3 id="curryRight"><a href="#curryRight" class="fa fa-link"></a><code>_.curryRight(func, [arity=func.length])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10243">source</a> <a href="https://www.npmjs.com/package/lodash.curryright">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10311">source</a> <a href="https://www.npmjs.com/package/lodash.curryright">npm package</a></p>
 <p>This method is like <a href="#curry"><code>_.curry</code></a> except that arguments are applied to <code>func</code>
 in the manner of <a href="#partialRight"><code>_.partialRight</code></a> instead of <a href="#partial"><code>_.partial</code></a>.
 <br>
@@ -2359,7 +2359,7 @@ builds, may be used as a placeholder for provided arguments.
 </div>
 <div>
 <h3 id="debounce"><a href="#debounce" class="fa fa-link"></a><code>_.debounce(func, [wait=0], [options={}])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10304">source</a> <a href="https://www.npmjs.com/package/lodash.debounce">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10372">source</a> <a href="https://www.npmjs.com/package/lodash.debounce">npm package</a></p>
 <p>Creates a debounced function that delays invoking <code>func</code> until after <code>wait</code>
 milliseconds have elapsed since the last time the debounced function was
 invoked. The debounced function comes with a <code>cancel</code> method to cancel
@@ -2401,7 +2401,7 @@ for details over the differences between <a href="#debounce"><code>_.debounce</c
 </div>
 <div>
 <h3 id="defer"><a href="#defer" class="fa fa-link"></a><code>_.defer(func, [args])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10447">source</a> <a href="https://www.npmjs.com/package/lodash.defer">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10515">source</a> <a href="https://www.npmjs.com/package/lodash.defer">npm package</a></p>
 <p>Defers invoking the <code>func</code> until the current call stack has cleared. Any
 additional arguments are provided to <code>func</code> when it&apos;s invoked.</p>
 <h4>Since</h4>
@@ -2419,7 +2419,7 @@ additional arguments are provided to <code>func</code> when it&apos;s invoked.</
 </div>
 <div>
 <h3 id="delay"><a href="#delay" class="fa fa-link"></a><code>_.delay(func, wait, [args])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10470">source</a> <a href="https://www.npmjs.com/package/lodash.delay">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10538">source</a> <a href="https://www.npmjs.com/package/lodash.delay">npm package</a></p>
 <p>Invokes <code>func</code> after <code>wait</code> milliseconds. Any additional arguments are
 provided to <code>func</code> when it&apos;s invoked.</p>
 <h4>Since</h4>
@@ -2438,7 +2438,7 @@ provided to <code>func</code> when it&apos;s invoked.</p>
 </div>
 <div>
 <h3 id="flip"><a href="#flip" class="fa fa-link"></a><code>_.flip(func)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10492">source</a> <a href="https://www.npmjs.com/package/lodash.flip">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10560">source</a> <a href="https://www.npmjs.com/package/lodash.flip">npm package</a></p>
 <p>Creates a function that invokes <code>func</code> with arguments reversed.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -2454,7 +2454,7 @@ provided to <code>func</code> when it&apos;s invoked.</p>
 </div>
 <div>
 <h3 id="memoize"><a href="#memoize" class="fa fa-link"></a><code>_.memoize(func, [resolver])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10540">source</a> <a href="https://www.npmjs.com/package/lodash.memoize">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10608">source</a> <a href="https://www.npmjs.com/package/lodash.memoize">npm package</a></p>
 <p>Creates a function that memoizes the result of <code>func</code>. If <code>resolver</code> is
 provided, it determines the cache key for storing the result based on the
 arguments provided to the memoized function. By default, the first argument
@@ -2482,7 +2482,7 @@ method interface of <code>clear</code>, <code>delete</code>, <code>get</code>, <
 </div>
 <div>
 <h3 id="negate"><a href="#negate" class="fa fa-link"></a><code>_.negate(predicate)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10583">source</a> <a href="https://www.npmjs.com/package/lodash.negate">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10651">source</a> <a href="https://www.npmjs.com/package/lodash.negate">npm package</a></p>
 <p>Creates a function that negates the result of the predicate <code>func</code>. The
 <code>func</code> predicate is invoked with the <code>this</code> binding and arguments of the
 created function.</p>
@@ -2500,7 +2500,7 @@ created function.</p>
 </div>
 <div>
 <h3 id="once"><a href="#once" class="fa fa-link"></a><code>_.once(func)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10617">source</a> <a href="https://www.npmjs.com/package/lodash.once">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10685">source</a> <a href="https://www.npmjs.com/package/lodash.once">npm package</a></p>
 <p>Creates a function that is restricted to invoking <code>func</code> once. Repeat calls
 to the function return the value of the first invocation. The <code>func</code> is
 invoked with the <code>this</code> binding and arguments of the created function.</p>
@@ -2518,7 +2518,7 @@ invoked with the <code>this</code> binding and arguments of the created function
 </div>
 <div>
 <h3 id="overArgs"><a href="#overArgs" class="fa fa-link"></a><code>_.overArgs(func, [transforms=[_.identity]])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10652">source</a> <a href="https://www.npmjs.com/package/lodash.overargs">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10720">source</a> <a href="https://www.npmjs.com/package/lodash.overargs">npm package</a></p>
 <p>Creates a function that invokes <code>func</code> with its arguments transformed.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -2535,7 +2535,7 @@ invoked with the <code>this</code> binding and arguments of the created function
 </div>
 <div>
 <h3 id="partial"><a href="#partial" class="fa fa-link"></a><code>_.partial(func, [partials])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10702">source</a> <a href="https://www.npmjs.com/package/lodash.partial">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10770">source</a> <a href="https://www.npmjs.com/package/lodash.partial">npm package</a></p>
 <p>Creates a function that invokes <code>func</code> with <code>partials</code> prepended to the
 arguments it receives. This method is like <a href="#bind"><code>_.bind</code></a> except it does <strong>not</strong>
 alter the <code>this</code> binding.
@@ -2562,7 +2562,7 @@ applied functions.</p>
 </div>
 <div>
 <h3 id="partialRight"><a href="#partialRight" class="fa fa-link"></a><code>_.partialRight(func, [partials])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10739">source</a> <a href="https://www.npmjs.com/package/lodash.partialright">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10807">source</a> <a href="https://www.npmjs.com/package/lodash.partialright">npm package</a></p>
 <p>This method is like <a href="#partial"><code>_.partial</code></a> except that partially applied arguments
 are appended to the arguments it receives.
 <br>
@@ -2588,7 +2588,7 @@ applied functions.</p>
 </div>
 <div>
 <h3 id="rearg"><a href="#rearg" class="fa fa-link"></a><code>_.rearg(func, indexes)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10766">source</a> <a href="https://www.npmjs.com/package/lodash.rearg">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10834">source</a> <a href="https://www.npmjs.com/package/lodash.rearg">npm package</a></p>
 <p>Creates a function that invokes <code>func</code> with arguments arranged according
 to the specified <code>indexes</code> where the argument value at the first index is
 provided as the first argument, the argument value at the second index is
@@ -2608,7 +2608,7 @@ provided as the second argument, and so on.</p>
 </div>
 <div>
 <h3 id="rest"><a href="#rest" class="fa fa-link"></a><code>_.rest(func, [start=func.length-1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10795">source</a> <a href="https://www.npmjs.com/package/lodash.rest">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10863">source</a> <a href="https://www.npmjs.com/package/lodash.rest">npm package</a></p>
 <p>Creates a function that invokes <code>func</code> with the <code>this</code> binding of the
 created function and arguments from <code>start</code> and beyond provided as
 an array.
@@ -2631,7 +2631,7 @@ an array.
 </div>
 <div>
 <h3 id="spread"><a href="#spread" class="fa fa-link"></a><code>_.spread(func, [start=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10837">source</a> <a href="https://www.npmjs.com/package/lodash.spread">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10905">source</a> <a href="https://www.npmjs.com/package/lodash.spread">npm package</a></p>
 <p>Creates a function that invokes <code>func</code> with the <code>this</code> binding of the
 create function and an array of arguments much like
 <a href="http://www.ecma-international.org/ecma-262/7.0/#sec-function.prototype.apply"><code>Function#apply</code></a>.
@@ -2654,7 +2654,7 @@ create function and an array of arguments much like
 </div>
 <div>
 <h3 id="throttle"><a href="#throttle" class="fa fa-link"></a><code>_.throttle(func, [wait=0], [options={}])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10897">source</a> <a href="https://www.npmjs.com/package/lodash.throttle">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10965">source</a> <a href="https://www.npmjs.com/package/lodash.throttle">npm package</a></p>
 <p>Creates a throttled function that only invokes <code>func</code> at most once per
 every <code>wait</code> milliseconds. The throttled function comes with a <code>cancel</code>
 method to cancel delayed <code>func</code> invocations and a <code>flush</code> method to
@@ -2694,7 +2694,7 @@ for details over the differences between <a href="#throttle"><code>_.throttle</c
 </div>
 <div>
 <h3 id="unary"><a href="#unary" class="fa fa-link"></a><code>_.unary(func)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10930">source</a> <a href="https://www.npmjs.com/package/lodash.unary">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10998">source</a> <a href="https://www.npmjs.com/package/lodash.unary">npm package</a></p>
 <p>Creates a function that accepts up to one argument, ignoring any
 additional arguments.</p>
 <h4>Since</h4>
@@ -2711,7 +2711,7 @@ additional arguments.</p>
 </div>
 <div>
 <h3 id="wrap"><a href="#wrap" class="fa fa-link"></a><code>_.wrap(value, [wrapper=identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10956">source</a> <a href="https://www.npmjs.com/package/lodash.wrap">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11024">source</a> <a href="https://www.npmjs.com/package/lodash.wrap">npm package</a></p>
 <p>Creates a function that provides <code>value</code> to <code>wrapper</code> as its first
 argument. Any additional arguments provided to the function are appended
 to those provided to the <code>wrapper</code>. The wrapper is invoked with the <code>this</code>
@@ -2734,7 +2734,7 @@ binding of the created function.</p>
 <h2><code>&#x201C;Lang&#x201D; Methods</code></h2>
 <div>
 <h3 id="castArray"><a href="#castArray" class="fa fa-link"></a><code>_.castArray(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L10995">source</a> <a href="https://www.npmjs.com/package/lodash.castarray">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11063">source</a> <a href="https://www.npmjs.com/package/lodash.castarray">npm package</a></p>
 <p>Casts <code>value</code> as an array if it&apos;s not one.</p>
 <h4>Since</h4>
 <p>4.4.0</p>
@@ -2750,7 +2750,7 @@ binding of the created function.</p>
 </div>
 <div>
 <h3 id="clone"><a href="#clone" class="fa fa-link"></a><code>_.clone(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11029">source</a> <a href="https://www.npmjs.com/package/lodash.clone">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11097">source</a> <a href="https://www.npmjs.com/package/lodash.clone">npm package</a></p>
 <p>Creates a shallow clone of <code>value</code>.
 <br>
 <br>
@@ -2775,7 +2775,7 @@ as error objects, functions, DOM nodes, and WeakMaps.</p>
 </div>
 <div>
 <h3 id="cloneDeep"><a href="#cloneDeep" class="fa fa-link"></a><code>_.cloneDeep(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11087">source</a> <a href="https://www.npmjs.com/package/lodash.clonedeep">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11155">source</a> <a href="https://www.npmjs.com/package/lodash.clonedeep">npm package</a></p>
 <p>This method is like <a href="#clone"><code>_.clone</code></a> except that it recursively clones <code>value</code>.</p>
 <h4>Since</h4>
 <p>1.0.0</p>
@@ -2791,7 +2791,7 @@ as error objects, functions, DOM nodes, and WeakMaps.</p>
 </div>
 <div>
 <h3 id="cloneDeepWith"><a href="#cloneDeepWith" class="fa fa-link"></a><code>_.cloneDeepWith(value, [customizer])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11119">source</a> <a href="https://www.npmjs.com/package/lodash.clonedeepwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11187">source</a> <a href="https://www.npmjs.com/package/lodash.clonedeepwith">npm package</a></p>
 <p>This method is like <a href="#cloneWith"><code>_.cloneWith</code></a> except that it recursively clones <code>value</code>.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -2808,7 +2808,7 @@ as error objects, functions, DOM nodes, and WeakMaps.</p>
 </div>
 <div>
 <h3 id="cloneWith"><a href="#cloneWith" class="fa fa-link"></a><code>_.cloneWith(value, [customizer])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11064">source</a> <a href="https://www.npmjs.com/package/lodash.clonewith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11132">source</a> <a href="https://www.npmjs.com/package/lodash.clonewith">npm package</a></p>
 <p>This method is like <a href="#clone"><code>_.clone</code></a> except that it accepts <code>customizer</code> which
 is invoked to produce the cloned value. If <code>customizer</code> returns <code>undefined</code>,
 cloning is handled by the method instead. The <code>customizer</code> is invoked with
@@ -2828,7 +2828,7 @@ up to four arguments; <em>(value [, index|key, object, stack])</em>.</p>
 </div>
 <div>
 <h3 id="conformsTo"><a href="#conformsTo" class="fa fa-link"></a><code>_.conformsTo(object, source)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11148">source</a> <a href="https://www.npmjs.com/package/lodash.conformsto">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11216">source</a> <a href="https://www.npmjs.com/package/lodash.conformsto">npm package</a></p>
 <p>Checks if <code>object</code> conforms to <code>source</code> by invoking the predicate
 properties of <code>source</code> with the corresponding property values of <code>object</code>.
 <br>
@@ -2850,7 +2850,7 @@ partially applied.</p>
 </div>
 <div>
 <h3 id="eq"><a href="#eq" class="fa fa-link"></a><code>_.eq(value, other)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11184">source</a> <a href="https://www.npmjs.com/package/lodash.eq">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11252">source</a> <a href="https://www.npmjs.com/package/lodash.eq">npm package</a></p>
 <p>Performs a
 <a href="http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero"><code>SameValueZero</code></a>
 comparison between two values to determine if they are equivalent.</p>
@@ -2869,7 +2869,7 @@ comparison between two values to determine if they are equivalent.</p>
 </div>
 <div>
 <h3 id="gt"><a href="#gt" class="fa fa-link"></a><code>_.gt(value, other)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11211">source</a> <a href="https://www.npmjs.com/package/lodash.gt">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11279">source</a> <a href="https://www.npmjs.com/package/lodash.gt">npm package</a></p>
 <p>Checks if <code>value</code> is greater than <code>other</code>.</p>
 <h4>Since</h4>
 <p>3.9.0</p>
@@ -2886,7 +2886,7 @@ comparison between two values to determine if they are equivalent.</p>
 </div>
 <div>
 <h3 id="gte"><a href="#gte" class="fa fa-link"></a><code>_.gte(value, other)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11236">source</a> <a href="https://www.npmjs.com/package/lodash.gte">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11304">source</a> <a href="https://www.npmjs.com/package/lodash.gte">npm package</a></p>
 <p>Checks if <code>value</code> is greater than or equal to <code>other</code>.</p>
 <h4>Since</h4>
 <p>3.9.0</p>
@@ -2903,7 +2903,7 @@ comparison between two values to determine if they are equivalent.</p>
 </div>
 <div>
 <h3 id="isArguments"><a href="#isArguments" class="fa fa-link"></a><code>_.isArguments(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11258">source</a> <a href="https://www.npmjs.com/package/lodash.isarguments">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11326">source</a> <a href="https://www.npmjs.com/package/lodash.isarguments">npm package</a></p>
 <p>Checks if <code>value</code> is likely an <code>arguments</code> object.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -2919,7 +2919,7 @@ comparison between two values to determine if they are equivalent.</p>
 </div>
 <div>
 <h3 id="isArray"><a href="#isArray" class="fa fa-link"></a><code>_.isArray(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11286">source</a> <a href="https://www.npmjs.com/package/lodash.isarray">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11354">source</a> <a href="https://www.npmjs.com/package/lodash.isarray">npm package</a></p>
 <p>Checks if <code>value</code> is classified as an <code>Array</code> object.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -2935,7 +2935,7 @@ comparison between two values to determine if they are equivalent.</p>
 </div>
 <div>
 <h3 id="isArrayBuffer"><a href="#isArrayBuffer" class="fa fa-link"></a><code>_.isArrayBuffer(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11305">source</a> <a href="https://www.npmjs.com/package/lodash.isarraybuffer">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11373">source</a> <a href="https://www.npmjs.com/package/lodash.isarraybuffer">npm package</a></p>
 <p>Checks if <code>value</code> is classified as an <code>ArrayBuffer</code> object.</p>
 <h4>Since</h4>
 <p>4.3.0</p>
@@ -2951,7 +2951,7 @@ comparison between two values to determine if they are equivalent.</p>
 </div>
 <div>
 <h3 id="isArrayLike"><a href="#isArrayLike" class="fa fa-link"></a><code>_.isArrayLike(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11332">source</a> <a href="https://www.npmjs.com/package/lodash.isarraylike">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11400">source</a> <a href="https://www.npmjs.com/package/lodash.isarraylike">npm package</a></p>
 <p>Checks if <code>value</code> is array-like. A value is considered array-like if it&apos;s
 not a function and has a <code>value.length</code> that&apos;s an integer greater than or
 equal to <code>0</code> and less than or equal to <code>Number.MAX_SAFE_INTEGER</code>.</p>
@@ -2969,7 +2969,7 @@ equal to <code>0</code> and less than or equal to <code>Number.MAX_SAFE_INTEGER<
 </div>
 <div>
 <h3 id="isArrayLikeObject"><a href="#isArrayLikeObject" class="fa fa-link"></a><code>_.isArrayLikeObject(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11361">source</a> <a href="https://www.npmjs.com/package/lodash.isarraylikeobject">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11429">source</a> <a href="https://www.npmjs.com/package/lodash.isarraylikeobject">npm package</a></p>
 <p>This method is like <a href="#isArrayLike"><code>_.isArrayLike</code></a> except that it also checks if <code>value</code>
 is an object.</p>
 <h4>Since</h4>
@@ -2986,7 +2986,7 @@ is an object.</p>
 </div>
 <div>
 <h3 id="isBoolean"><a href="#isBoolean" class="fa fa-link"></a><code>_.isBoolean(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11382">source</a> <a href="https://www.npmjs.com/package/lodash.isboolean">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11450">source</a> <a href="https://www.npmjs.com/package/lodash.isboolean">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a boolean primitive or object.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -3002,7 +3002,7 @@ is an object.</p>
 </div>
 <div>
 <h3 id="isBuffer"><a href="#isBuffer" class="fa fa-link"></a><code>_.isBuffer(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11404">source</a> <a href="https://www.npmjs.com/package/lodash.isbuffer">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11472">source</a> <a href="https://www.npmjs.com/package/lodash.isbuffer">npm package</a></p>
 <p>Checks if <code>value</code> is a buffer.</p>
 <h4>Since</h4>
 <p>4.3.0</p>
@@ -3018,7 +3018,7 @@ is an object.</p>
 </div>
 <div>
 <h3 id="isDate"><a href="#isDate" class="fa fa-link"></a><code>_.isDate(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11423">source</a> <a href="https://www.npmjs.com/package/lodash.isdate">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11491">source</a> <a href="https://www.npmjs.com/package/lodash.isdate">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a <code>Date</code> object.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -3034,7 +3034,7 @@ is an object.</p>
 </div>
 <div>
 <h3 id="isElement"><a href="#isElement" class="fa fa-link"></a><code>_.isElement(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11442">source</a> <a href="https://www.npmjs.com/package/lodash.iselement">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11510">source</a> <a href="https://www.npmjs.com/package/lodash.iselement">npm package</a></p>
 <p>Checks if <code>value</code> is likely a DOM element.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -3050,7 +3050,7 @@ is an object.</p>
 </div>
 <div>
 <h3 id="isEmpty"><a href="#isEmpty" class="fa fa-link"></a><code>_.isEmpty(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11479">source</a> <a href="https://www.npmjs.com/package/lodash.isempty">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11547">source</a> <a href="https://www.npmjs.com/package/lodash.isempty">npm package</a></p>
 <p>Checks if <code>value</code> is an empty object, collection, map, or set.
 <br>
 <br>
@@ -3075,7 +3075,7 @@ Similarly, maps and sets are considered empty if they have a <code>size</code> o
 </div>
 <div>
 <h3 id="isEqual"><a href="#isEqual" class="fa fa-link"></a><code>_.isEqual(value, other)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11531">source</a> <a href="https://www.npmjs.com/package/lodash.isequal">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11599">source</a> <a href="https://www.npmjs.com/package/lodash.isequal">npm package</a></p>
 <p>Performs a deep comparison between two values to determine if they are
 equivalent.
 <br>
@@ -3100,7 +3100,7 @@ nodes are compared by strict equality, i.e. <code>===</code>.</p>
 </div>
 <div>
 <h3 id="isEqualWith"><a href="#isEqualWith" class="fa fa-link"></a><code>_.isEqualWith(value, other, [customizer])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11567">source</a> <a href="https://www.npmjs.com/package/lodash.isequalwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11635">source</a> <a href="https://www.npmjs.com/package/lodash.isequalwith">npm package</a></p>
 <p>This method is like <a href="#isEqual"><code>_.isEqual</code></a> except that it accepts <code>customizer</code> which
 is invoked to compare values. If <code>customizer</code> returns <code>undefined</code>, comparisons
 are handled by the method instead. The <code>customizer</code> is invoked with up to
@@ -3121,7 +3121,7 @@ six arguments: <em>(objValue, othValue [, index|key, object, other, stack])</em>
 </div>
 <div>
 <h3 id="isError"><a href="#isError" class="fa fa-link"></a><code>_.isError(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11591">source</a> <a href="https://www.npmjs.com/package/lodash.iserror">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11659">source</a> <a href="https://www.npmjs.com/package/lodash.iserror">npm package</a></p>
 <p>Checks if <code>value</code> is an <code>Error</code>, <code>EvalError</code>, <code>RangeError</code>, <code>ReferenceError</code>,
 <code>SyntaxError</code>, <code>TypeError</code>, or <code>URIError</code> object.</p>
 <h4>Since</h4>
@@ -3138,7 +3138,7 @@ six arguments: <em>(objValue, othValue [, index|key, object, other, stack])</em>
 </div>
 <div>
 <h3 id="isFinite"><a href="#isFinite" class="fa fa-link"></a><code>_.isFinite(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11626">source</a> <a href="https://www.npmjs.com/package/lodash.isfinite">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11694">source</a> <a href="https://www.npmjs.com/package/lodash.isfinite">npm package</a></p>
 <p>Checks if <code>value</code> is a finite primitive number.
 <br>
 <br>
@@ -3158,7 +3158,7 @@ six arguments: <em>(objValue, othValue [, index|key, object, other, stack])</em>
 </div>
 <div>
 <h3 id="isFunction"><a href="#isFunction" class="fa fa-link"></a><code>_.isFunction(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11647">source</a> <a href="https://www.npmjs.com/package/lodash.isfunction">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11715">source</a> <a href="https://www.npmjs.com/package/lodash.isfunction">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a <code>Function</code> object.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -3174,7 +3174,7 @@ six arguments: <em>(objValue, othValue [, index|key, object, other, stack])</em>
 </div>
 <div>
 <h3 id="isInteger"><a href="#isInteger" class="fa fa-link"></a><code>_.isInteger(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11683">source</a> <a href="https://www.npmjs.com/package/lodash.isinteger">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11751">source</a> <a href="https://www.npmjs.com/package/lodash.isinteger">npm package</a></p>
 <p>Checks if <code>value</code> is an integer.
 <br>
 <br>
@@ -3194,7 +3194,7 @@ six arguments: <em>(objValue, othValue [, index|key, object, other, stack])</em>
 </div>
 <div>
 <h3 id="isLength"><a href="#isLength" class="fa fa-link"></a><code>_.isLength(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11713">source</a> <a href="https://www.npmjs.com/package/lodash.islength">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11781">source</a> <a href="https://www.npmjs.com/package/lodash.islength">npm package</a></p>
 <p>Checks if <code>value</code> is a valid array-like length.
 <br>
 <br>
@@ -3214,7 +3214,7 @@ six arguments: <em>(objValue, othValue [, index|key, object, other, stack])</em>
 </div>
 <div>
 <h3 id="isMap"><a href="#isMap" class="fa fa-link"></a><code>_.isMap(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11793">source</a> <a href="https://www.npmjs.com/package/lodash.ismap">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11861">source</a> <a href="https://www.npmjs.com/package/lodash.ismap">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a <code>Map</code> object.</p>
 <h4>Since</h4>
 <p>4.3.0</p>
@@ -3230,7 +3230,7 @@ six arguments: <em>(objValue, othValue [, index|key, object, other, stack])</em>
 </div>
 <div>
 <h3 id="isMatch"><a href="#isMatch" class="fa fa-link"></a><code>_.isMatch(object, source)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11823">source</a> <a href="https://www.npmjs.com/package/lodash.ismatch">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11891">source</a> <a href="https://www.npmjs.com/package/lodash.ismatch">npm package</a></p>
 <p>Performs a partial deep comparison between <code>object</code> and <code>source</code> to
 determine if <code>object</code> contains equivalent property values.
 <br>
@@ -3257,7 +3257,7 @@ for a list of supported value comparisons.</p>
 </div>
 <div>
 <h3 id="isMatchWith"><a href="#isMatchWith" class="fa fa-link"></a><code>_.isMatchWith(object, source, [customizer])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11859">source</a> <a href="https://www.npmjs.com/package/lodash.ismatchwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11927">source</a> <a href="https://www.npmjs.com/package/lodash.ismatchwith">npm package</a></p>
 <p>This method is like <a href="#isMatch"><code>_.isMatch</code></a> except that it accepts <code>customizer</code> which
 is invoked to compare values. If <code>customizer</code> returns <code>undefined</code>, comparisons
 are handled by the method instead. The <code>customizer</code> is invoked with five
@@ -3278,7 +3278,7 @@ arguments: <em>(objValue, srcValue, index|key, object, source)</em>.</p>
 </div>
 <div>
 <h3 id="isNaN"><a href="#isNaN" class="fa fa-link"></a><code>_.isNaN(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11892">source</a> <a href="https://www.npmjs.com/package/lodash.isnan">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11960">source</a> <a href="https://www.npmjs.com/package/lodash.isnan">npm package</a></p>
 <p>Checks if <code>value</code> is <code>NaN</code>.
 <br>
 <br>
@@ -3300,7 +3300,7 @@ global <a href="https://mdn.io/isNaN"><code>isNaN</code></a> which returns <code
 </div>
 <div>
 <h3 id="isNative"><a href="#isNative" class="fa fa-link"></a><code>_.isNative(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11925">source</a> <a href="https://www.npmjs.com/package/lodash.isnative">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11993">source</a> <a href="https://www.npmjs.com/package/lodash.isnative">npm package</a></p>
 <p>Checks if <code>value</code> is a pristine native function.
 <br>
 <br>
@@ -3325,7 +3325,7 @@ which rely on core-js.</p>
 </div>
 <div>
 <h3 id="isNil"><a href="#isNil" class="fa fa-link"></a><code>_.isNil(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11973">source</a> <a href="https://www.npmjs.com/package/lodash.isnil">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12041">source</a> <a href="https://www.npmjs.com/package/lodash.isnil">npm package</a></p>
 <p>Checks if <code>value</code> is <code>null</code> or <code>undefined</code>.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -3341,7 +3341,7 @@ which rely on core-js.</p>
 </div>
 <div>
 <h3 id="isNull"><a href="#isNull" class="fa fa-link"></a><code>_.isNull(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11949">source</a> <a href="https://www.npmjs.com/package/lodash.isnull">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12017">source</a> <a href="https://www.npmjs.com/package/lodash.isnull">npm package</a></p>
 <p>Checks if <code>value</code> is <code>null</code>.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -3357,7 +3357,7 @@ which rely on core-js.</p>
 </div>
 <div>
 <h3 id="isNumber"><a href="#isNumber" class="fa fa-link"></a><code>_.isNumber(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12003">source</a> <a href="https://www.npmjs.com/package/lodash.isnumber">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12071">source</a> <a href="https://www.npmjs.com/package/lodash.isnumber">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a <code>Number</code> primitive or object.
 <br>
 <br>
@@ -3377,7 +3377,7 @@ classified as numbers, use the <a href="#isFinite"><code>_.isFinite</code></a> m
 </div>
 <div>
 <h3 id="isObject"><a href="#isObject" class="fa fa-link"></a><code>_.isObject(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11743">source</a> <a href="https://www.npmjs.com/package/lodash.isobject">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11811">source</a> <a href="https://www.npmjs.com/package/lodash.isobject">npm package</a></p>
 <p>Checks if <code>value</code> is the
 <a href="http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types">language type</a>
 of <code>Object</code>. <em>(e.g. arrays, functions, objects, regexes, <code>new Number(0)</code>, and <code>new String(&apos;&apos;)</code>)</em></p>
@@ -3395,7 +3395,7 @@ of <code>Object</code>. <em>(e.g. arrays, functions, objects, regexes, <code>new
 </div>
 <div>
 <h3 id="isObjectLike"><a href="#isObjectLike" class="fa fa-link"></a><code>_.isObjectLike(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11772">source</a> <a href="https://www.npmjs.com/package/lodash.isobjectlike">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L11840">source</a> <a href="https://www.npmjs.com/package/lodash.isobjectlike">npm package</a></p>
 <p>Checks if <code>value</code> is object-like. A value is object-like if it&apos;s not <code>null</code>
 and has a <code>typeof</code> result of &quot;object&quot;.</p>
 <h4>Since</h4>
@@ -3412,7 +3412,7 @@ and has a <code>typeof</code> result of &quot;object&quot;.</p>
 </div>
 <div>
 <h3 id="isPlainObject"><a href="#isPlainObject" class="fa fa-link"></a><code>_.isPlainObject(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12036">source</a> <a href="https://www.npmjs.com/package/lodash.isplainobject">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12104">source</a> <a href="https://www.npmjs.com/package/lodash.isplainobject">npm package</a></p>
 <p>Checks if <code>value</code> is a plain object, that is, an object created by the
 <code>Object</code> constructor or one with a <code>[[Prototype]]</code> of <code>null</code>.</p>
 <h4>Since</h4>
@@ -3429,7 +3429,7 @@ and has a <code>typeof</code> result of &quot;object&quot;.</p>
 </div>
 <div>
 <h3 id="isRegExp"><a href="#isRegExp" class="fa fa-link"></a><code>_.isRegExp(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12066">source</a> <a href="https://www.npmjs.com/package/lodash.isregexp">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12134">source</a> <a href="https://www.npmjs.com/package/lodash.isregexp">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a <code>RegExp</code> object.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -3445,7 +3445,7 @@ and has a <code>typeof</code> result of &quot;object&quot;.</p>
 </div>
 <div>
 <h3 id="isSafeInteger"><a href="#isSafeInteger" class="fa fa-link"></a><code>_.isSafeInteger(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12095">source</a> <a href="https://www.npmjs.com/package/lodash.issafeinteger">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12163">source</a> <a href="https://www.npmjs.com/package/lodash.issafeinteger">npm package</a></p>
 <p>Checks if <code>value</code> is a safe integer. An integer is safe if it&apos;s an IEEE-754
 double precision number which isn&apos;t the result of a rounded unsafe integer.
 <br>
@@ -3466,7 +3466,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="isSet"><a href="#isSet" class="fa fa-link"></a><code>_.isSet(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12116">source</a> <a href="https://www.npmjs.com/package/lodash.isset">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12184">source</a> <a href="https://www.npmjs.com/package/lodash.isset">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a <code>Set</code> object.</p>
 <h4>Since</h4>
 <p>4.3.0</p>
@@ -3482,7 +3482,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="isString"><a href="#isString" class="fa fa-link"></a><code>_.isString(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12135">source</a> <a href="https://www.npmjs.com/package/lodash.isstring">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12203">source</a> <a href="https://www.npmjs.com/package/lodash.isstring">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a <code>String</code> primitive or object.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -3498,7 +3498,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="isSymbol"><a href="#isSymbol" class="fa fa-link"></a><code>_.isSymbol(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12157">source</a> <a href="https://www.npmjs.com/package/lodash.issymbol">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12225">source</a> <a href="https://www.npmjs.com/package/lodash.issymbol">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a <code>Symbol</code> primitive or object.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -3514,7 +3514,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="isTypedArray"><a href="#isTypedArray" class="fa fa-link"></a><code>_.isTypedArray(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12179">source</a> <a href="https://www.npmjs.com/package/lodash.istypedarray">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12247">source</a> <a href="https://www.npmjs.com/package/lodash.istypedarray">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a typed array.</p>
 <h4>Since</h4>
 <p>3.0.0</p>
@@ -3530,7 +3530,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="isUndefined"><a href="#isUndefined" class="fa fa-link"></a><code>_.isUndefined(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12198">source</a> <a href="https://www.npmjs.com/package/lodash.isundefined">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12266">source</a> <a href="https://www.npmjs.com/package/lodash.isundefined">npm package</a></p>
 <p>Checks if <code>value</code> is <code>undefined</code>.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -3546,7 +3546,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="isWeakMap"><a href="#isWeakMap" class="fa fa-link"></a><code>_.isWeakMap(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12219">source</a> <a href="https://www.npmjs.com/package/lodash.isweakmap">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12287">source</a> <a href="https://www.npmjs.com/package/lodash.isweakmap">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a <code>WeakMap</code> object.</p>
 <h4>Since</h4>
 <p>4.3.0</p>
@@ -3562,7 +3562,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="isWeakSet"><a href="#isWeakSet" class="fa fa-link"></a><code>_.isWeakSet(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12240">source</a> <a href="https://www.npmjs.com/package/lodash.isweakset">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12308">source</a> <a href="https://www.npmjs.com/package/lodash.isweakset">npm package</a></p>
 <p>Checks if <code>value</code> is classified as a <code>WeakSet</code> object.</p>
 <h4>Since</h4>
 <p>4.3.0</p>
@@ -3578,7 +3578,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="lt"><a href="#lt" class="fa fa-link"></a><code>_.lt(value, other)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12267">source</a> <a href="https://www.npmjs.com/package/lodash.lt">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12335">source</a> <a href="https://www.npmjs.com/package/lodash.lt">npm package</a></p>
 <p>Checks if <code>value</code> is less than <code>other</code>.</p>
 <h4>Since</h4>
 <p>3.9.0</p>
@@ -3595,7 +3595,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="lte"><a href="#lte" class="fa fa-link"></a><code>_.lte(value, other)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12292">source</a> <a href="https://www.npmjs.com/package/lodash.lte">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12360">source</a> <a href="https://www.npmjs.com/package/lodash.lte">npm package</a></p>
 <p>Checks if <code>value</code> is less than or equal to <code>other</code>.</p>
 <h4>Since</h4>
 <p>3.9.0</p>
@@ -3612,7 +3612,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="toArray"><a href="#toArray" class="fa fa-link"></a><code>_.toArray(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12319">source</a> <a href="https://www.npmjs.com/package/lodash.toarray">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12387">source</a> <a href="https://www.npmjs.com/package/lodash.toarray">npm package</a></p>
 <p>Converts <code>value</code> to an array.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -3628,7 +3628,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="toFinite"><a href="#toFinite" class="fa fa-link"></a><code>_.toFinite(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12358">source</a> <a href="https://www.npmjs.com/package/lodash.tofinite">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12426">source</a> <a href="https://www.npmjs.com/package/lodash.tofinite">npm package</a></p>
 <p>Converts <code>value</code> to a finite number.</p>
 <h4>Since</h4>
 <p>4.12.0</p>
@@ -3644,7 +3644,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="toInteger"><a href="#toInteger" class="fa fa-link"></a><code>_.toInteger(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12396">source</a> <a href="https://www.npmjs.com/package/lodash.tointeger">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12464">source</a> <a href="https://www.npmjs.com/package/lodash.tointeger">npm package</a></p>
 <p>Converts <code>value</code> to an integer.
 <br>
 <br>
@@ -3664,7 +3664,7 @@ double precision number which isn&apos;t the result of a rounded unsafe integer.
 </div>
 <div>
 <h3 id="toLength"><a href="#toLength" class="fa fa-link"></a><code>_.toLength(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12430">source</a> <a href="https://www.npmjs.com/package/lodash.tolength">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12498">source</a> <a href="https://www.npmjs.com/package/lodash.tolength">npm package</a></p>
 <p>Converts <code>value</code> to an integer suitable for use as the length of an
 array-like object.
 <br>
@@ -3685,7 +3685,7 @@ array-like object.
 </div>
 <div>
 <h3 id="toNumber"><a href="#toNumber" class="fa fa-link"></a><code>_.toNumber(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12457">source</a> <a href="https://www.npmjs.com/package/lodash.tonumber">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12525">source</a> <a href="https://www.npmjs.com/package/lodash.tonumber">npm package</a></p>
 <p>Converts <code>value</code> to a number.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -3701,7 +3701,7 @@ array-like object.
 </div>
 <div>
 <h3 id="toPlainObject"><a href="#toPlainObject" class="fa fa-link"></a><code>_.toPlainObject(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12502">source</a> <a href="https://www.npmjs.com/package/lodash.toplainobject">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12570">source</a> <a href="https://www.npmjs.com/package/lodash.toplainobject">npm package</a></p>
 <p>Converts <code>value</code> to a plain object flattening inherited enumerable string
 keyed properties of <code>value</code> to own properties of the plain object.</p>
 <h4>Since</h4>
@@ -3718,7 +3718,7 @@ keyed properties of <code>value</code> to own properties of the plain object.</p
 </div>
 <div>
 <h3 id="toSafeInteger"><a href="#toSafeInteger" class="fa fa-link"></a><code>_.toSafeInteger(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12530">source</a> <a href="https://www.npmjs.com/package/lodash.tosafeinteger">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12598">source</a> <a href="https://www.npmjs.com/package/lodash.tosafeinteger">npm package</a></p>
 <p>Converts <code>value</code> to a safe integer. A safe integer can be compared and
 represented correctly.</p>
 <h4>Since</h4>
@@ -3735,7 +3735,7 @@ represented correctly.</p>
 </div>
 <div>
 <h3 id="toString"><a href="#toString" class="fa fa-link"></a><code>_.toString(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12557">source</a> <a href="https://www.npmjs.com/package/lodash.tostring">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12625">source</a> <a href="https://www.npmjs.com/package/lodash.tostring">npm package</a></p>
 <p>Converts <code>value</code> to a string. An empty string is returned for <code>null</code>
 and <code>undefined</code> values. The sign of <code>-0</code> is preserved.</p>
 <h4>Since</h4>
@@ -3755,7 +3755,7 @@ and <code>undefined</code> values. The sign of <code>-0</code> is preserved.</p>
 <h2><code>&#x201C;Math&#x201D; Methods</code></h2>
 <div>
 <h3 id="add"><a href="#add" class="fa fa-link"></a><code>_.add(augend, addend)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16192">source</a> <a href="https://www.npmjs.com/package/lodash.add">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16289">source</a> <a href="https://www.npmjs.com/package/lodash.add">npm package</a></p>
 <p>Adds two numbers.</p>
 <h4>Since</h4>
 <p>3.4.0</p>
@@ -3772,7 +3772,7 @@ and <code>undefined</code> values. The sign of <code>-0</code> is preserved.</p>
 </div>
 <div>
 <h3 id="ceil"><a href="#ceil" class="fa fa-link"></a><code>_.ceil(number, [precision=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16217">source</a> <a href="https://www.npmjs.com/package/lodash.ceil">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16314">source</a> <a href="https://www.npmjs.com/package/lodash.ceil">npm package</a></p>
 <p>Computes <code>number</code> rounded up to <code>precision</code>.</p>
 <h4>Since</h4>
 <p>3.10.0</p>
@@ -3789,7 +3789,7 @@ and <code>undefined</code> values. The sign of <code>-0</code> is preserved.</p>
 </div>
 <div>
 <h3 id="divide"><a href="#divide" class="fa fa-link"></a><code>_.divide(dividend, divisor)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16234">source</a> <a href="https://www.npmjs.com/package/lodash.divide">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16331">source</a> <a href="https://www.npmjs.com/package/lodash.divide">npm package</a></p>
 <p>Divide two numbers.</p>
 <h4>Since</h4>
 <p>4.7.0</p>
@@ -3806,7 +3806,7 @@ and <code>undefined</code> values. The sign of <code>-0</code> is preserved.</p>
 </div>
 <div>
 <h3 id="floor"><a href="#floor" class="fa fa-link"></a><code>_.floor(number, [precision=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16259">source</a> <a href="https://www.npmjs.com/package/lodash.floor">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16356">source</a> <a href="https://www.npmjs.com/package/lodash.floor">npm package</a></p>
 <p>Computes <code>number</code> rounded down to <code>precision</code>.</p>
 <h4>Since</h4>
 <p>3.10.0</p>
@@ -3823,7 +3823,7 @@ and <code>undefined</code> values. The sign of <code>-0</code> is preserved.</p>
 </div>
 <div>
 <h3 id="max"><a href="#max" class="fa fa-link"></a><code>_.max(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16279">source</a> <a href="https://www.npmjs.com/package/lodash.max">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16376">source</a> <a href="https://www.npmjs.com/package/lodash.max">npm package</a></p>
 <p>Computes the maximum value of <code>array</code>. If <code>array</code> is empty or falsey,
 <code>undefined</code> is returned.</p>
 <h4>Since</h4>
@@ -3840,7 +3840,7 @@ and <code>undefined</code> values. The sign of <code>-0</code> is preserved.</p>
 </div>
 <div>
 <h3 id="maxBy"><a href="#maxBy" class="fa fa-link"></a><code>_.maxBy(array, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16308">source</a> <a href="https://www.npmjs.com/package/lodash.maxby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16405">source</a> <a href="https://www.npmjs.com/package/lodash.maxby">npm package</a></p>
 <p>This method is like <a href="#max"><code>_.max</code></a> except that it accepts <code>iteratee</code> which is
 invoked for each element in <code>array</code> to generate the criterion by which
 the value is ranked. The iteratee is invoked with one argument: <em>(value)</em>.</p>
@@ -3859,7 +3859,7 @@ the value is ranked. The iteratee is invoked with one argument: <em>(value)</em>
 </div>
 <div>
 <h3 id="mean"><a href="#mean" class="fa fa-link"></a><code>_.mean(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16328">source</a> <a href="https://www.npmjs.com/package/lodash.mean">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16425">source</a> <a href="https://www.npmjs.com/package/lodash.mean">npm package</a></p>
 <p>Computes the mean of the values in <code>array</code>.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -3875,7 +3875,7 @@ the value is ranked. The iteratee is invoked with one argument: <em>(value)</em>
 </div>
 <div>
 <h3 id="meanBy"><a href="#meanBy" class="fa fa-link"></a><code>_.meanBy(array, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16355">source</a> <a href="https://www.npmjs.com/package/lodash.meanby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16452">source</a> <a href="https://www.npmjs.com/package/lodash.meanby">npm package</a></p>
 <p>This method is like <a href="#mean"><code>_.mean</code></a> except that it accepts <code>iteratee</code> which is
 invoked for each element in <code>array</code> to generate the value to be averaged.
 The iteratee is invoked with one argument: <em>(value)</em>.</p>
@@ -3894,7 +3894,7 @@ The iteratee is invoked with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="min"><a href="#min" class="fa fa-link"></a><code>_.min(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16377">source</a> <a href="https://www.npmjs.com/package/lodash.min">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16474">source</a> <a href="https://www.npmjs.com/package/lodash.min">npm package</a></p>
 <p>Computes the minimum value of <code>array</code>. If <code>array</code> is empty or falsey,
 <code>undefined</code> is returned.</p>
 <h4>Since</h4>
@@ -3911,7 +3911,7 @@ The iteratee is invoked with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="minBy"><a href="#minBy" class="fa fa-link"></a><code>_.minBy(array, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16406">source</a> <a href="https://www.npmjs.com/package/lodash.minby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16503">source</a> <a href="https://www.npmjs.com/package/lodash.minby">npm package</a></p>
 <p>This method is like <a href="#min"><code>_.min</code></a> except that it accepts <code>iteratee</code> which is
 invoked for each element in <code>array</code> to generate the criterion by which
 the value is ranked. The iteratee is invoked with one argument: <em>(value)</em>.</p>
@@ -3930,7 +3930,7 @@ the value is ranked. The iteratee is invoked with one argument: <em>(value)</em>
 </div>
 <div>
 <h3 id="multiply"><a href="#multiply" class="fa fa-link"></a><code>_.multiply(multiplier, multiplicand)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16427">source</a> <a href="https://www.npmjs.com/package/lodash.multiply">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16524">source</a> <a href="https://www.npmjs.com/package/lodash.multiply">npm package</a></p>
 <p>Multiply two numbers.</p>
 <h4>Since</h4>
 <p>4.7.0</p>
@@ -3947,7 +3947,7 @@ the value is ranked. The iteratee is invoked with one argument: <em>(value)</em>
 </div>
 <div>
 <h3 id="round"><a href="#round" class="fa fa-link"></a><code>_.round(number, [precision=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16452">source</a> <a href="https://www.npmjs.com/package/lodash.round">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16549">source</a> <a href="https://www.npmjs.com/package/lodash.round">npm package</a></p>
 <p>Computes <code>number</code> rounded to <code>precision</code>.</p>
 <h4>Since</h4>
 <p>3.10.0</p>
@@ -3964,7 +3964,7 @@ the value is ranked. The iteratee is invoked with one argument: <em>(value)</em>
 </div>
 <div>
 <h3 id="subtract"><a href="#subtract" class="fa fa-link"></a><code>_.subtract(minuend, subtrahend)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16469">source</a> <a href="https://www.npmjs.com/package/lodash.subtract">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16566">source</a> <a href="https://www.npmjs.com/package/lodash.subtract">npm package</a></p>
 <p>Subtract two numbers.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -3981,7 +3981,7 @@ the value is ranked. The iteratee is invoked with one argument: <em>(value)</em>
 </div>
 <div>
 <h3 id="sum"><a href="#sum" class="fa fa-link"></a><code>_.sum(array)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16487">source</a> <a href="https://www.npmjs.com/package/lodash.sum">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16584">source</a> <a href="https://www.npmjs.com/package/lodash.sum">npm package</a></p>
 <p>Computes the sum of the values in <code>array</code>.</p>
 <h4>Since</h4>
 <p>3.4.0</p>
@@ -3997,7 +3997,7 @@ the value is ranked. The iteratee is invoked with one argument: <em>(value)</em>
 </div>
 <div>
 <h3 id="sumBy"><a href="#sumBy" class="fa fa-link"></a><code>_.sumBy(array, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16516">source</a> <a href="https://www.npmjs.com/package/lodash.sumby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16613">source</a> <a href="https://www.npmjs.com/package/lodash.sumby">npm package</a></p>
 <p>This method is like <a href="#sum"><code>_.sum</code></a> except that it accepts <code>iteratee</code> which is
 invoked for each element in <code>array</code> to generate the value to be summed.
 The iteratee is invoked with one argument: <em>(value)</em>.</p>
@@ -4019,7 +4019,7 @@ The iteratee is invoked with one argument: <em>(value)</em>.</p>
 <h2><code>&#x201C;Number&#x201D; Methods</code></h2>
 <div>
 <h3 id="clamp"><a href="#clamp" class="fa fa-link"></a><code>_.clamp(number, [lower], upper)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13981">source</a> <a href="https://www.npmjs.com/package/lodash.clamp">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14049">source</a> <a href="https://www.npmjs.com/package/lodash.clamp">npm package</a></p>
 <p>Clamps <code>number</code> within the inclusive <code>lower</code> and <code>upper</code> bounds.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -4037,7 +4037,7 @@ The iteratee is invoked with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="inRange"><a href="#inRange" class="fa fa-link"></a><code>_.inRange(number, [start=0], end)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14035">source</a> <a href="https://www.npmjs.com/package/lodash.inrange">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14103">source</a> <a href="https://www.npmjs.com/package/lodash.inrange">npm package</a></p>
 <p>Checks if <code>n</code> is between <code>start</code> and up to, but not including, <code>end</code>. If
 <code>end</code> is not specified, it&apos;s set to <code>start</code> with <code>start</code> then set to <code>0</code>.
 If <code>start</code> is greater than <code>end</code> the params are swapped to support
@@ -4058,7 +4058,7 @@ negative ranges.</p>
 </div>
 <div>
 <h3 id="random"><a href="#random" class="fa fa-link"></a><code>_.random([lower=0], [upper=1], [floating])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14078">source</a> <a href="https://www.npmjs.com/package/lodash.random">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14146">source</a> <a href="https://www.npmjs.com/package/lodash.random">npm package</a></p>
 <p>Produces a random number between the inclusive <code>lower</code> and <code>upper</code> bounds.
 If only one argument is provided a number between <code>0</code> and the given number
 is returned. If <code>floating</code> is <code>true</code>, or either <code>lower</code> or <code>upper</code> are
@@ -4086,7 +4086,7 @@ floating-point values which can produce unexpected results.</p>
 <h2><code>&#x201C;Object&#x201D; Methods</code></h2>
 <div>
 <h3 id="assign"><a href="#assign" class="fa fa-link"></a><code>_.assign(object, [sources])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12595">source</a> <a href="https://www.npmjs.com/package/lodash.assign">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12663">source</a> <a href="https://www.npmjs.com/package/lodash.assign">npm package</a></p>
 <p>Assigns own enumerable string keyed properties of source objects to the
 destination object. Source objects are applied from left to right.
 Subsequent sources overwrite property assignments of previous sources.
@@ -4109,7 +4109,7 @@ Subsequent sources overwrite property assignments of previous sources.
 </div>
 <div>
 <h3 id="assignIn"><a href="#assignIn" class="fa fa-link"></a><code>_.assignIn(object, [sources])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12638">source</a> <a href="https://www.npmjs.com/package/lodash.assignin">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12706">source</a> <a href="https://www.npmjs.com/package/lodash.assignin">npm package</a></p>
 <p>This method is like <a href="#assign"><code>_.assign</code></a> except that it iterates over own and
 inherited source properties.
 <br>
@@ -4132,7 +4132,7 @@ inherited source properties.
 </div>
 <div>
 <h3 id="assignInWith"><a href="#assignInWith" class="fa fa-link"></a><code>_.assignInWith(object, sources, [customizer])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12671">source</a> <a href="https://www.npmjs.com/package/lodash.assigninwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12739">source</a> <a href="https://www.npmjs.com/package/lodash.assigninwith">npm package</a></p>
 <p>This method is like <a href="#assignIn"><code>_.assignIn</code></a> except that it accepts <code>customizer</code>
 which is invoked to produce the assigned values. If <code>customizer</code> returns
 <code>undefined</code>, assignment is handled by the method instead. The <code>customizer</code>
@@ -4158,7 +4158,7 @@ is invoked with five arguments: <em>(objValue, srcValue, key, object, source)</e
 </div>
 <div>
 <h3 id="assignWith"><a href="#assignWith" class="fa fa-link"></a><code>_.assignWith(object, sources, [customizer])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12703">source</a> <a href="https://www.npmjs.com/package/lodash.assignwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12771">source</a> <a href="https://www.npmjs.com/package/lodash.assignwith">npm package</a></p>
 <p>This method is like <a href="#assign"><code>_.assign</code></a> except that it accepts <code>customizer</code>
 which is invoked to produce the assigned values. If <code>customizer</code> returns
 <code>undefined</code>, assignment is handled by the method instead. The <code>customizer</code>
@@ -4182,7 +4182,7 @@ is invoked with five arguments: <em>(objValue, srcValue, key, object, source)</e
 </div>
 <div>
 <h3 id="at"><a href="#at" class="fa fa-link"></a><code>_.at(object, [paths])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12724">source</a> <a href="https://www.npmjs.com/package/lodash.at">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12792">source</a> <a href="https://www.npmjs.com/package/lodash.at">npm package</a></p>
 <p>Creates an array of values corresponding to <code>paths</code> of <code>object</code>.</p>
 <h4>Since</h4>
 <p>1.0.0</p>
@@ -4199,7 +4199,7 @@ is invoked with five arguments: <em>(objValue, srcValue, key, object, source)</e
 </div>
 <div>
 <h3 id="create"><a href="#create" class="fa fa-link"></a><code>_.create(prototype, [properties])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12760">source</a> <a href="https://www.npmjs.com/package/lodash.create">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12828">source</a> <a href="https://www.npmjs.com/package/lodash.create">npm package</a></p>
 <p>Creates an object that inherits from the <code>prototype</code> object. If a
 <code>properties</code> object is given, its own enumerable string keyed properties
 are assigned to the created object.</p>
@@ -4218,7 +4218,7 @@ are assigned to the created object.</p>
 </div>
 <div>
 <h3 id="defaults"><a href="#defaults" class="fa fa-link"></a><code>_.defaults(object, [sources])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12786">source</a> <a href="https://www.npmjs.com/package/lodash.defaults">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12854">source</a> <a href="https://www.npmjs.com/package/lodash.defaults">npm package</a></p>
 <p>Assigns own and inherited enumerable string keyed properties of source
 objects to the destination object for all destination properties that
 resolve to <code>undefined</code>. Source objects are applied from left to right.
@@ -4241,7 +4241,7 @@ Once a property is set, additional values of the same property are ignored.
 </div>
 <div>
 <h3 id="defaultsDeep"><a href="#defaultsDeep" class="fa fa-link"></a><code>_.defaultsDeep(object, [sources])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12836">source</a> <a href="https://www.npmjs.com/package/lodash.defaultsdeep">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12904">source</a> <a href="https://www.npmjs.com/package/lodash.defaultsdeep">npm package</a></p>
 <p>This method is like <a href="#defaults"><code>_.defaults</code></a> except that it recursively assigns
 default properties.
 <br>
@@ -4262,7 +4262,7 @@ default properties.
 </div>
 <div>
 <h3 id="findKey"><a href="#findKey" class="fa fa-link"></a><code>_.findKey(object, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12876">source</a> <a href="https://www.npmjs.com/package/lodash.findkey">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12944">source</a> <a href="https://www.npmjs.com/package/lodash.findkey">npm package</a></p>
 <p>This method is like <a href="#find"><code>_.find</code></a> except that it returns the key of the first
 element <code>predicate</code> returns truthy for instead of the element itself.</p>
 <h4>Since</h4>
@@ -4280,7 +4280,7 @@ element <code>predicate</code> returns truthy for instead of the element itself.
 </div>
 <div>
 <h3 id="findLastKey"><a href="#findLastKey" class="fa fa-link"></a><code>_.findLastKey(object, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12915">source</a> <a href="https://www.npmjs.com/package/lodash.findlastkey">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L12983">source</a> <a href="https://www.npmjs.com/package/lodash.findlastkey">npm package</a></p>
 <p>This method is like <a href="#findKey"><code>_.findKey</code></a> except that it iterates over elements of
 a collection in the opposite order.</p>
 <h4>Since</h4>
@@ -4298,7 +4298,7 @@ a collection in the opposite order.</p>
 </div>
 <div>
 <h3 id="forIn"><a href="#forIn" class="fa fa-link"></a><code>_.forIn(object, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12947">source</a> <a href="https://www.npmjs.com/package/lodash.forin">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13015">source</a> <a href="https://www.npmjs.com/package/lodash.forin">npm package</a></p>
 <p>Iterates over own and inherited enumerable string keyed properties of an
 object and invokes <code>iteratee</code> for each property. The iteratee is invoked
 with three arguments: <em>(value, key, object)</em>. Iteratee functions may exit
@@ -4318,7 +4318,7 @@ iteration early by explicitly returning <code>false</code>.</p>
 </div>
 <div>
 <h3 id="forInRight"><a href="#forInRight" class="fa fa-link"></a><code>_.forInRight(object, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L12979">source</a> <a href="https://www.npmjs.com/package/lodash.forinright">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13047">source</a> <a href="https://www.npmjs.com/package/lodash.forinright">npm package</a></p>
 <p>This method is like <a href="#forIn"><code>_.forIn</code></a> except that it iterates over properties of
 <code>object</code> in the opposite order.</p>
 <h4>Since</h4>
@@ -4336,7 +4336,7 @@ iteration early by explicitly returning <code>false</code>.</p>
 </div>
 <div>
 <h3 id="forOwn"><a href="#forOwn" class="fa fa-link"></a><code>_.forOwn(object, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13013">source</a> <a href="https://www.npmjs.com/package/lodash.forown">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13081">source</a> <a href="https://www.npmjs.com/package/lodash.forown">npm package</a></p>
 <p>Iterates over own enumerable string keyed properties of an object and
 invokes <code>iteratee</code> for each property. The iteratee is invoked with three
 arguments: <em>(value, key, object)</em>. Iteratee functions may exit iteration
@@ -4356,7 +4356,7 @@ early by explicitly returning <code>false</code>.</p>
 </div>
 <div>
 <h3 id="forOwnRight"><a href="#forOwnRight" class="fa fa-link"></a><code>_.forOwnRight(object, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13043">source</a> <a href="https://www.npmjs.com/package/lodash.forownright">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13111">source</a> <a href="https://www.npmjs.com/package/lodash.forownright">npm package</a></p>
 <p>This method is like <a href="#forOwn"><code>_.forOwn</code></a> except that it iterates over properties of
 <code>object</code> in the opposite order.</p>
 <h4>Since</h4>
@@ -4374,7 +4374,7 @@ early by explicitly returning <code>false</code>.</p>
 </div>
 <div>
 <h3 id="functions"><a href="#functions" class="fa fa-link"></a><code>_.functions(object)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13070">source</a> <a href="https://www.npmjs.com/package/lodash.functions">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13138">source</a> <a href="https://www.npmjs.com/package/lodash.functions">npm package</a></p>
 <p>Creates an array of function property names from own enumerable properties
 of <code>object</code>.</p>
 <h4>Since</h4>
@@ -4391,7 +4391,7 @@ of <code>object</code>.</p>
 </div>
 <div>
 <h3 id="functionsIn"><a href="#functionsIn" class="fa fa-link"></a><code>_.functionsIn(object)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13097">source</a> <a href="https://www.npmjs.com/package/lodash.functionsin">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13165">source</a> <a href="https://www.npmjs.com/package/lodash.functionsin">npm package</a></p>
 <p>Creates an array of function property names from own and inherited
 enumerable properties of <code>object</code>.</p>
 <h4>Since</h4>
@@ -4408,7 +4408,7 @@ enumerable properties of <code>object</code>.</p>
 </div>
 <div>
 <h3 id="get"><a href="#get" class="fa fa-link"></a><code>_.get(object, path, [defaultValue])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13126">source</a> <a href="https://www.npmjs.com/package/lodash.get">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13194">source</a> <a href="https://www.npmjs.com/package/lodash.get">npm package</a></p>
 <p>Gets the value at <code>path</code> of <code>object</code>. If the resolved value is
 <code>undefined</code>, the <code>defaultValue</code> is returned in its place.</p>
 <h4>Since</h4>
@@ -4427,7 +4427,7 @@ enumerable properties of <code>object</code>.</p>
 </div>
 <div>
 <h3 id="has"><a href="#has" class="fa fa-link"></a><code>_.has(object, path)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13158">source</a> <a href="https://www.npmjs.com/package/lodash.has">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13226">source</a> <a href="https://www.npmjs.com/package/lodash.has">npm package</a></p>
 <p>Checks if <code>path</code> is a direct property of <code>object</code>.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -4444,7 +4444,7 @@ enumerable properties of <code>object</code>.</p>
 </div>
 <div>
 <h3 id="hasIn"><a href="#hasIn" class="fa fa-link"></a><code>_.hasIn(object, path)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13188">source</a> <a href="https://www.npmjs.com/package/lodash.hasin">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13256">source</a> <a href="https://www.npmjs.com/package/lodash.hasin">npm package</a></p>
 <p>Checks if <code>path</code> is a direct or inherited property of <code>object</code>.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -4461,7 +4461,7 @@ enumerable properties of <code>object</code>.</p>
 </div>
 <div>
 <h3 id="invert"><a href="#invert" class="fa fa-link"></a><code>_.invert(object)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13210">source</a> <a href="https://www.npmjs.com/package/lodash.invert">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13278">source</a> <a href="https://www.npmjs.com/package/lodash.invert">npm package</a></p>
 <p>Creates an object composed of the inverted keys and values of <code>object</code>.
 If <code>object</code> contains duplicate values, subsequent values overwrite
 property assignments of previous values.</p>
@@ -4479,7 +4479,7 @@ property assignments of previous values.</p>
 </div>
 <div>
 <h3 id="invertBy"><a href="#invertBy" class="fa fa-link"></a><code>_.invertBy(object, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13245">source</a> <a href="https://www.npmjs.com/package/lodash.invertby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13313">source</a> <a href="https://www.npmjs.com/package/lodash.invertby">npm package</a></p>
 <p>This method is like <a href="#invert"><code>_.invert</code></a> except that the inverted object is generated
 from the results of running each element of <code>object</code> thru <code>iteratee</code>. The
 corresponding inverted value of each inverted key is an array of keys
@@ -4500,7 +4500,7 @@ with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="invoke"><a href="#invoke" class="fa fa-link"></a><code>_.invoke(object, path, [args])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13276">source</a> <a href="https://www.npmjs.com/package/lodash.invoke">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13344">source</a> <a href="https://www.npmjs.com/package/lodash.invoke">npm package</a></p>
 <p>Invokes the method at <code>path</code> of <code>object</code>.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -4518,7 +4518,7 @@ with one argument: <em>(value)</em>.</p>
 </div>
 <div>
 <h3 id="keys"><a href="#keys" class="fa fa-link"></a><code>_.keys(object)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13306">source</a> <a href="https://www.npmjs.com/package/lodash.keys">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13374">source</a> <a href="https://www.npmjs.com/package/lodash.keys">npm package</a></p>
 <p>Creates an array of the own enumerable property names of <code>object</code>.
 <br>
 <br>
@@ -4539,7 +4539,7 @@ for more details.</p>
 </div>
 <div>
 <h3 id="keysIn"><a href="#keysIn" class="fa fa-link"></a><code>_.keysIn(object)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13333">source</a> <a href="https://www.npmjs.com/package/lodash.keysin">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13401">source</a> <a href="https://www.npmjs.com/package/lodash.keysin">npm package</a></p>
 <p>Creates an array of the own and inherited enumerable property names of <code>object</code>.
 <br>
 <br>
@@ -4558,7 +4558,7 @@ for more details.</p>
 </div>
 <div>
 <h3 id="mapKeys"><a href="#mapKeys" class="fa fa-link"></a><code>_.mapKeys(object, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13358">source</a> <a href="https://www.npmjs.com/package/lodash.mapkeys">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13426">source</a> <a href="https://www.npmjs.com/package/lodash.mapkeys">npm package</a></p>
 <p>The opposite of <a href="#mapValues"><code>_.mapValues</code></a>; this method creates an object with the
 same values as <code>object</code> and keys generated by running each own enumerable
 string keyed property of <code>object</code> thru <code>iteratee</code>. The iteratee is invoked
@@ -4578,7 +4578,7 @@ with three arguments: <em>(value, key, object)</em>.</p>
 </div>
 <div>
 <h3 id="mapValues"><a href="#mapValues" class="fa fa-link"></a><code>_.mapValues(object, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13396">source</a> <a href="https://www.npmjs.com/package/lodash.mapvalues">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13464">source</a> <a href="https://www.npmjs.com/package/lodash.mapvalues">npm package</a></p>
 <p>Creates an object with the same keys as <code>object</code> and values generated
 by running each own enumerable string keyed property of <code>object</code> thru
 <code>iteratee</code>. The iteratee is invoked with three arguments:<br>
@@ -4598,7 +4598,7 @@ by running each own enumerable string keyed property of <code>object</code> thru
 </div>
 <div>
 <h3 id="merge"><a href="#merge" class="fa fa-link"></a><code>_.merge(object, [sources])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13437">source</a> <a href="https://www.npmjs.com/package/lodash.merge">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13505">source</a> <a href="https://www.npmjs.com/package/lodash.merge">npm package</a></p>
 <p>This method is like <a href="#assign"><code>_.assign</code></a> except that it recursively merges own and
 inherited enumerable string keyed properties of source objects into the
 destination object. Source properties that resolve to <code>undefined</code> are
@@ -4624,7 +4624,7 @@ sources overwrite property assignments of previous sources.
 </div>
 <div>
 <h3 id="mergeWith"><a href="#mergeWith" class="fa fa-link"></a><code>_.mergeWith(object, sources, customizer)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13472">source</a> <a href="https://www.npmjs.com/package/lodash.mergewith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13540">source</a> <a href="https://www.npmjs.com/package/lodash.mergewith">npm package</a></p>
 <p>This method is like <a href="#merge"><code>_.merge</code></a> except that it accepts <code>customizer</code> which
 is invoked to produce the merged values of the destination and source
 properties. If <code>customizer</code> returns <code>undefined</code>, merging is handled by the
@@ -4649,7 +4649,7 @@ method instead. The <code>customizer</code> is invoked with six arguments:<br>
 </div>
 <div>
 <h3 id="omit"><a href="#omit" class="fa fa-link"></a><code>_.omit(object, [paths])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13496">source</a> <a href="https://www.npmjs.com/package/lodash.omit">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13564">source</a> <a href="https://www.npmjs.com/package/lodash.omit">npm package</a></p>
 <p>The opposite of <a href="#pick"><code>_.pick</code></a>; this method creates an object composed of the
 own and inherited enumerable property paths of <code>object</code> that are not omitted.
 <br>
@@ -4670,7 +4670,7 @@ own and inherited enumerable property paths of <code>object</code> that are not 
 </div>
 <div>
 <h3 id="omitBy"><a href="#omitBy" class="fa fa-link"></a><code>_.omitBy(object, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13538">source</a> <a href="https://www.npmjs.com/package/lodash.omitby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13606">source</a> <a href="https://www.npmjs.com/package/lodash.omitby">npm package</a></p>
 <p>The opposite of <a href="#pickBy"><code>_.pickBy</code></a>; this method creates an object composed of
 the own and inherited enumerable string keyed properties of <code>object</code> that
 <code>predicate</code> doesn&apos;t return truthy for. The predicate is invoked with two
@@ -4690,7 +4690,7 @@ arguments: <em>(value, key)</em>.</p>
 </div>
 <div>
 <h3 id="pick"><a href="#pick" class="fa fa-link"></a><code>_.pick(object, [paths])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13559">source</a> <a href="https://www.npmjs.com/package/lodash.pick">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13627">source</a> <a href="https://www.npmjs.com/package/lodash.pick">npm package</a></p>
 <p>Creates an object composed of the picked <code>object</code> properties.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -4707,7 +4707,7 @@ arguments: <em>(value, key)</em>.</p>
 </div>
 <div>
 <h3 id="pickBy"><a href="#pickBy" class="fa fa-link"></a><code>_.pickBy(object, [predicate=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13581">source</a> <a href="https://www.npmjs.com/package/lodash.pickby">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13649">source</a> <a href="https://www.npmjs.com/package/lodash.pickby">npm package</a></p>
 <p>Creates an object composed of the <code>object</code> properties <code>predicate</code> returns
 truthy for. The predicate is invoked with two arguments: <em>(value, key)</em>.</p>
 <h4>Since</h4>
@@ -4725,7 +4725,7 @@ truthy for. The predicate is invoked with two arguments: <em>(value, key)</em>.<
 </div>
 <div>
 <h3 id="result"><a href="#result" class="fa fa-link"></a><code>_.result(object, path, [defaultValue])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13623">source</a> <a href="https://www.npmjs.com/package/lodash.result">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13691">source</a> <a href="https://www.npmjs.com/package/lodash.result">npm package</a></p>
 <p>This method is like <a href="#get"><code>_.get</code></a> except that if the resolved value is a
 function it&apos;s invoked with the <code>this</code> binding of its parent object and
 its result is returned.</p>
@@ -4745,7 +4745,7 @@ its result is returned.</p>
 </div>
 <div>
 <h3 id="set"><a href="#set" class="fa fa-link"></a><code>_.set(object, path, value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13673">source</a> <a href="https://www.npmjs.com/package/lodash.set">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13741">source</a> <a href="https://www.npmjs.com/package/lodash.set">npm package</a></p>
 <p>Sets the value at <code>path</code> of <code>object</code>. If a portion of <code>path</code> doesn&apos;t exist,
 it&apos;s created. Arrays are created for missing index properties while objects
 are created for all other missing properties. Use <a href="#setWith"><code>_.setWith</code></a> to customize
@@ -4769,7 +4769,7 @@ are created for all other missing properties. Use <a href="#setWith"><code>_.set
 </div>
 <div>
 <h3 id="setWith"><a href="#setWith" class="fa fa-link"></a><code>_.setWith(object, path, value, [customizer])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13701">source</a> <a href="https://www.npmjs.com/package/lodash.setwith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13769">source</a> <a href="https://www.npmjs.com/package/lodash.setwith">npm package</a></p>
 <p>This method is like <a href="#set"><code>_.set</code></a> except that it accepts <code>customizer</code> which is
 invoked to produce the objects of <code>path</code>.  If <code>customizer</code> returns <code>undefined</code>
 path creation is handled by the method instead. The <code>customizer</code> is invoked
@@ -4794,7 +4794,7 @@ with three arguments: <em>(nsValue, key, nsObject)</em>.
 </div>
 <div>
 <h3 id="toPairs"><a href="#toPairs" class="fa fa-link"></a><code>_.toPairs(object)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13730">source</a> <a href="https://www.npmjs.com/package/lodash.topairs">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13798">source</a> <a href="https://www.npmjs.com/package/lodash.topairs">npm package</a></p>
 <p>Creates an array of own enumerable string keyed-value pairs for <code>object</code>
 which can be consumed by <a href="#fromPairs"><code>_.fromPairs</code></a>. If <code>object</code> is a map or set, its
 entries are returned.</p>
@@ -4814,7 +4814,7 @@ entries are returned.</p>
 </div>
 <div>
 <h3 id="toPairsIn"><a href="#toPairsIn" class="fa fa-link"></a><code>_.toPairsIn(object)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13756">source</a> <a href="https://www.npmjs.com/package/lodash.topairsin">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13824">source</a> <a href="https://www.npmjs.com/package/lodash.topairsin">npm package</a></p>
 <p>Creates an array of own and inherited enumerable string keyed-value pairs
 for <code>object</code> which can be consumed by <a href="#fromPairs"><code>_.fromPairs</code></a>. If <code>object</code> is a map
 or set, its entries are returned.</p>
@@ -4834,7 +4834,7 @@ or set, its entries are returned.</p>
 </div>
 <div>
 <h3 id="transform"><a href="#transform" class="fa fa-link"></a><code>_.transform(object, [iteratee=_.identity], [accumulator])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13788">source</a> <a href="https://www.npmjs.com/package/lodash.transform">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13856">source</a> <a href="https://www.npmjs.com/package/lodash.transform">npm package</a></p>
 <p>An alternative to <a href="#reduce"><code>_.reduce</code></a>; this method transforms <code>object</code> to a new
 <code>accumulator</code> object which is the result of running each of its own
 enumerable string keyed properties thru <code>iteratee</code>, with each invocation
@@ -4858,7 +4858,7 @@ Iteratee functions may exit iteration early by explicitly returning <code>false<
 </div>
 <div>
 <h3 id="unset"><a href="#unset" class="fa fa-link"></a><code>_.unset(object, path)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13838">source</a> <a href="https://www.npmjs.com/package/lodash.unset">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13906">source</a> <a href="https://www.npmjs.com/package/lodash.unset">npm package</a></p>
 <p>Removes the property at <code>path</code> of <code>object</code>.
 <br>
 <br>
@@ -4878,7 +4878,7 @@ Iteratee functions may exit iteration early by explicitly returning <code>false<
 </div>
 <div>
 <h3 id="update"><a href="#update" class="fa fa-link"></a><code>_.update(object, path, updater)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13869">source</a> <a href="https://www.npmjs.com/package/lodash.update">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13937">source</a> <a href="https://www.npmjs.com/package/lodash.update">npm package</a></p>
 <p>This method is like <a href="#set"><code>_.set</code></a> except that accepts <code>updater</code> to produce the
 value to set. Use <a href="#updateWith"><code>_.updateWith</code></a> to customize <code>path</code> creation. The <code>updater</code>
 is invoked with one argument: <em>(value)</em>.
@@ -4901,7 +4901,7 @@ is invoked with one argument: <em>(value)</em>.
 </div>
 <div>
 <h3 id="updateWith"><a href="#updateWith" class="fa fa-link"></a><code>_.updateWith(object, path, updater, [customizer])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13897">source</a> <a href="https://www.npmjs.com/package/lodash.updatewith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13965">source</a> <a href="https://www.npmjs.com/package/lodash.updatewith">npm package</a></p>
 <p>This method is like <a href="#update"><code>_.update</code></a> except that it accepts <code>customizer</code> which is
 invoked to produce the objects of <code>path</code>.  If <code>customizer</code> returns <code>undefined</code>
 path creation is handled by the method instead. The <code>customizer</code> is invoked
@@ -4926,7 +4926,7 @@ with three arguments: <em>(nsValue, key, nsObject)</em>.
 </div>
 <div>
 <h3 id="values"><a href="#values" class="fa fa-link"></a><code>_.values(object)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13928">source</a> <a href="https://www.npmjs.com/package/lodash.values">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L13996">source</a> <a href="https://www.npmjs.com/package/lodash.values">npm package</a></p>
 <p>Creates an array of the own enumerable string keyed property values of <code>object</code>.
 <br>
 <br>
@@ -4945,7 +4945,7 @@ with three arguments: <em>(nsValue, key, nsObject)</em>.
 </div>
 <div>
 <h3 id="valuesIn"><a href="#valuesIn" class="fa fa-link"></a><code>_.valuesIn(object)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L13956">source</a> <a href="https://www.npmjs.com/package/lodash.valuesin">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14024">source</a> <a href="https://www.npmjs.com/package/lodash.valuesin">npm package</a></p>
 <p>Creates an array of the own and inherited enumerable string keyed property
 values of <code>object</code>.
 <br>
@@ -4968,7 +4968,7 @@ values of <code>object</code>.
 <h2><code>&#x201C;Seq&#x201D; Methods</code></h2>
 <div>
 <h3 id="lodash"><a href="#lodash" class="fa fa-link"></a><code>_(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L1648">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L1690)
 <p>Creates a <code>lodash</code> object which wraps <code>value</code> to enable implicit method
 chain sequences. Methods that operate on and return arrays, collections,
 and functions can be chained together. Methods that retrieve a single value
@@ -5080,7 +5080,7 @@ The wrapper methods that are <strong>not</strong> chainable by default are:<br>
 </div>
 <div>
 <h3 id="chain"><a href="#chain" class="fa fa-link"></a><code>_.chain(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8737">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8801)
 <p>Creates a <code>lodash</code> wrapper instance that wraps <code>value</code> with explicit method
 chain sequences enabled. The result of such sequences must be unwrapped
 with <code>_#value</code>.</p>
@@ -5098,7 +5098,7 @@ with <code>_#value</code>.</p>
 </div>
 <div>
 <h3 id="tap"><a href="#tap" class="fa fa-link"></a><code>_.tap(value, interceptor)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8766">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8830)
 <p>This method invokes <code>interceptor</code> and returns <code>value</code>. The interceptor
 is invoked with one argument; <em>(value)</em>. The purpose of this method is to
 &quot;tap into&quot; a method chain sequence in order to modify intermediate results.</p>
@@ -5117,7 +5117,7 @@ is invoked with one argument; <em>(value)</em>. The purpose of this method is to
 </div>
 <div>
 <h3 id="thru"><a href="#thru" class="fa fa-link"></a><code>_.thru(value, interceptor)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8794">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8858)
 <p>This method is like <a href="#tap"><code>_.tap</code></a> except that it returns the result of <code>interceptor</code>.
 The purpose of this method is to &quot;pass thru&quot; values replacing intermediate
 results in a method chain sequence.</p>
@@ -5136,7 +5136,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-Symbol-iterator"><a href="#prototype-Symbol-iterator" class="fa fa-link"></a><code>_.prototype[Symbol.iterator]()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8949">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9013)
 <p>Enables the wrapper to be iterable.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -5148,7 +5148,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-at"><a href="#prototype-at" class="fa fa-link"></a><code>_.prototype.at([paths])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8814">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8878)
 <p>This method is the wrapper version of <a href="#at"><code>_.at</code></a>.</p>
 <h4>Since</h4>
 <p>1.0.0</p>
@@ -5164,7 +5164,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-chain"><a href="#prototype-chain" class="fa fa-link"></a><code>_.prototype.chain()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8865">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8929)
 <p>Creates a <code>lodash</code> wrapper instance with explicit method chain sequences enabled.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -5176,7 +5176,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-commit"><a href="#prototype-commit" class="fa fa-link"></a><code>_.prototype.commit()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8895">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8959)
 <p>Executes the chain sequence and returns the wrapped result.</p>
 <h4>Since</h4>
 <p>3.2.0</p>
@@ -5188,7 +5188,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-next"><a href="#prototype-next" class="fa fa-link"></a><code>_.prototype.next()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8921">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L8985)
 <p>Gets the next value on a wrapped object following the
 <a href="https://mdn.io/iteration_protocols#iterator">iterator protocol</a>.</p>
 <h4>Since</h4>
@@ -5201,7 +5201,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-plant"><a href="#prototype-plant" class="fa fa-link"></a><code>_.prototype.plant(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L8977">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9041)
 <p>Creates a clone of the chain sequence planting <code>value</code> as the wrapped value.</p>
 <h4>Since</h4>
 <p>3.2.0</p>
@@ -5217,7 +5217,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-reverse"><a href="#prototype-reverse" class="fa fa-link"></a><code>_.prototype.reverse()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9017">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9081)
 <p>This method is the wrapper version of <a href="#reverse"><code>_.reverse</code></a>.
 <br>
 <br>
@@ -5232,7 +5232,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-value"><a href="#prototype-value" class="fa fa-link"></a><code>_.prototype.value()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L9049">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L9113)
 <p>Executes the chain sequence to resolve the unwrapped value.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -5249,7 +5249,7 @@ results in a method chain sequence.</p>
 <h2><code>&#x201C;String&#x201D; Methods</code></h2>
 <div>
 <h3 id="camelCase"><a href="#camelCase" class="fa fa-link"></a><code>_.camelCase([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14139">source</a> <a href="https://www.npmjs.com/package/lodash.camelcase">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14207">source</a> <a href="https://www.npmjs.com/package/lodash.camelcase">npm package</a></p>
 <p>Converts <code>string</code> to <a href="https://en.wikipedia.org/wiki/CamelCase">camel case</a>.</p>
 <h4>Since</h4>
 <p>3.0.0</p>
@@ -5265,7 +5265,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="capitalize"><a href="#capitalize" class="fa fa-link"></a><code>_.capitalize([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14159">source</a> <a href="https://www.npmjs.com/package/lodash.capitalize">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14227">source</a> <a href="https://www.npmjs.com/package/lodash.capitalize">npm package</a></p>
 <p>Converts the first character of <code>string</code> to upper case and the remaining
 to lower case.</p>
 <h4>Since</h4>
@@ -5282,7 +5282,7 @@ to lower case.</p>
 </div>
 <div>
 <h3 id="deburr"><a href="#deburr" class="fa fa-link"></a><code>_.deburr([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14181">source</a> <a href="https://www.npmjs.com/package/lodash.deburr">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14249">source</a> <a href="https://www.npmjs.com/package/lodash.deburr">npm package</a></p>
 <p>Deburrs <code>string</code> by converting
 <a href="https://en.wikipedia.org/wiki/Latin-1_Supplement_(Unicode_block)#Character_table">Latin-1 Supplement</a>
 and <a href="https://en.wikipedia.org/wiki/Latin_Extended-A">Latin Extended-A</a>
@@ -5302,7 +5302,7 @@ letters to basic Latin letters and removing
 </div>
 <div>
 <h3 id="endsWith"><a href="#endsWith" class="fa fa-link"></a><code>_.endsWith([string=&apos;&apos;], [target], [position=string.length])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14209">source</a> <a href="https://www.npmjs.com/package/lodash.endswith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14277">source</a> <a href="https://www.npmjs.com/package/lodash.endswith">npm package</a></p>
 <p>Checks if <code>string</code> ends with the given target string.</p>
 <h4>Since</h4>
 <p>3.0.0</p>
@@ -5320,7 +5320,7 @@ letters to basic Latin letters and removing
 </div>
 <div>
 <h3 id="escape"><a href="#escape" class="fa fa-link"></a><code>_.escape([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14251">source</a> <a href="https://www.npmjs.com/package/lodash.escape">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14319">source</a> <a href="https://www.npmjs.com/package/lodash.escape">npm package</a></p>
 <p>Converts the characters &quot;&amp;&quot;, &quot;&lt;&quot;, &quot;&gt;&quot;, &apos;&quot;&apos;, and &quot;&apos;&quot; in <code>string</code> to their
 corresponding HTML entities.
 <br>
@@ -5353,7 +5353,7 @@ XSS vectors.</p>
 </div>
 <div>
 <h3 id="escapeRegExp"><a href="#escapeRegExp" class="fa fa-link"></a><code>_.escapeRegExp([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14273">source</a> <a href="https://www.npmjs.com/package/lodash.escaperegexp">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14341">source</a> <a href="https://www.npmjs.com/package/lodash.escaperegexp">npm package</a></p>
 <p>Escapes the <code>RegExp</code> special characters &quot;^&quot;, &quot;$&quot;, &quot;&quot;, &quot;.&quot;, &quot;*&quot;, &quot;+&quot;,
 &quot;?&quot;, &quot;(&quot;, &quot;)&quot;, &quot;[&quot;, &quot;]&quot;, &quot;{&quot;, &quot;}&quot;, and &quot;|&quot; in <code>string</code>.</p>
 <h4>Since</h4>
@@ -5370,7 +5370,7 @@ XSS vectors.</p>
 </div>
 <div>
 <h3 id="kebabCase"><a href="#kebabCase" class="fa fa-link"></a><code>_.kebabCase([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14301">source</a> <a href="https://www.npmjs.com/package/lodash.kebabcase">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14369">source</a> <a href="https://www.npmjs.com/package/lodash.kebabcase">npm package</a></p>
 <p>Converts <code>string</code> to
 <a href="https://en.wikipedia.org/wiki/Letter_case#Special_case_styles">kebab case</a>.</p>
 <h4>Since</h4>
@@ -5387,7 +5387,7 @@ XSS vectors.</p>
 </div>
 <div>
 <h3 id="lowerCase"><a href="#lowerCase" class="fa fa-link"></a><code>_.lowerCase([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14325">source</a> <a href="https://www.npmjs.com/package/lodash.lowercase">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14393">source</a> <a href="https://www.npmjs.com/package/lodash.lowercase">npm package</a></p>
 <p>Converts <code>string</code>, as space separated words, to lower case.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -5403,7 +5403,7 @@ XSS vectors.</p>
 </div>
 <div>
 <h3 id="lowerFirst"><a href="#lowerFirst" class="fa fa-link"></a><code>_.lowerFirst([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14346">source</a> <a href="https://www.npmjs.com/package/lodash.lowerfirst">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14414">source</a> <a href="https://www.npmjs.com/package/lodash.lowerfirst">npm package</a></p>
 <p>Converts the first character of <code>string</code> to lower case.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -5419,7 +5419,7 @@ XSS vectors.</p>
 </div>
 <div>
 <h3 id="pad"><a href="#pad" class="fa fa-link"></a><code>_.pad([string=&apos;&apos;], [length=0], [chars=&apos; &apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14371">source</a> <a href="https://www.npmjs.com/package/lodash.pad">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14439">source</a> <a href="https://www.npmjs.com/package/lodash.pad">npm package</a></p>
 <p>Pads <code>string</code> on the left and right sides if it&apos;s shorter than <code>length</code>.
 Padding characters are truncated if they can&apos;t be evenly divided by <code>length</code>.</p>
 <h4>Since</h4>
@@ -5438,7 +5438,7 @@ Padding characters are truncated if they can&apos;t be evenly divided by <code>l
 </div>
 <div>
 <h3 id="padEnd"><a href="#padEnd" class="fa fa-link"></a><code>_.padEnd([string=&apos;&apos;], [length=0], [chars=&apos; &apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14410">source</a> <a href="https://www.npmjs.com/package/lodash.padend">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14478">source</a> <a href="https://www.npmjs.com/package/lodash.padend">npm package</a></p>
 <p>Pads <code>string</code> on the right side if it&apos;s shorter than <code>length</code>. Padding
 characters are truncated if they exceed <code>length</code>.</p>
 <h4>Since</h4>
@@ -5457,7 +5457,7 @@ characters are truncated if they exceed <code>length</code>.</p>
 </div>
 <div>
 <h3 id="padStart"><a href="#padStart" class="fa fa-link"></a><code>_.padStart([string=&apos;&apos;], [length=0], [chars=&apos; &apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14443">source</a> <a href="https://www.npmjs.com/package/lodash.padstart">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14511">source</a> <a href="https://www.npmjs.com/package/lodash.padstart">npm package</a></p>
 <p>Pads <code>string</code> on the left side if it&apos;s shorter than <code>length</code>. Padding
 characters are truncated if they exceed <code>length</code>.</p>
 <h4>Since</h4>
@@ -5476,7 +5476,7 @@ characters are truncated if they exceed <code>length</code>.</p>
 </div>
 <div>
 <h3 id="parseInt"><a href="#parseInt" class="fa fa-link"></a><code>_.parseInt(string, [radix=10])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14477">source</a> <a href="https://www.npmjs.com/package/lodash.parseint">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14545">source</a> <a href="https://www.npmjs.com/package/lodash.parseint">npm package</a></p>
 <p>Converts <code>string</code> to an integer of the specified radix. If <code>radix</code> is
 <code>undefined</code> or <code>0</code>, a <code>radix</code> of <code>10</code> is used unless <code>value</code> is a
 hexadecimal, in which case a <code>radix</code> of <code>16</code> is used.
@@ -5499,7 +5499,7 @@ hexadecimal, in which case a <code>radix</code> of <code>16</code> is used.
 </div>
 <div>
 <h3 id="repeat"><a href="#repeat" class="fa fa-link"></a><code>_.repeat([string=&apos;&apos;], [n=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14508">source</a> <a href="https://www.npmjs.com/package/lodash.repeat">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14576">source</a> <a href="https://www.npmjs.com/package/lodash.repeat">npm package</a></p>
 <p>Repeats the given string <code>n</code> times.</p>
 <h4>Since</h4>
 <p>3.0.0</p>
@@ -5516,7 +5516,7 @@ hexadecimal, in which case a <code>radix</code> of <code>16</code> is used.
 </div>
 <div>
 <h3 id="replace"><a href="#replace" class="fa fa-link"></a><code>_.replace([string=&apos;&apos;], pattern, replacement)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14536">source</a> <a href="https://www.npmjs.com/package/lodash.replace">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14604">source</a> <a href="https://www.npmjs.com/package/lodash.replace">npm package</a></p>
 <p>Replaces matches for <code>pattern</code> in <code>string</code> with <code>replacement</code>.
 <br>
 <br>
@@ -5538,7 +5538,7 @@ hexadecimal, in which case a <code>radix</code> of <code>16</code> is used.
 </div>
 <div>
 <h3 id="snakeCase"><a href="#snakeCase" class="fa fa-link"></a><code>_.snakeCase([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14564">source</a> <a href="https://www.npmjs.com/package/lodash.snakecase">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14632">source</a> <a href="https://www.npmjs.com/package/lodash.snakecase">npm package</a></p>
 <p>Converts <code>string</code> to
 <a href="https://en.wikipedia.org/wiki/Snake_case">snake case</a>.</p>
 <h4>Since</h4>
@@ -5555,7 +5555,7 @@ hexadecimal, in which case a <code>radix</code> of <code>16</code> is used.
 </div>
 <div>
 <h3 id="split"><a href="#split" class="fa fa-link"></a><code>_.split([string=&apos;&apos;], separator, [limit])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14587">source</a> <a href="https://www.npmjs.com/package/lodash.split">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14655">source</a> <a href="https://www.npmjs.com/package/lodash.split">npm package</a></p>
 <p>Splits <code>string</code> by <code>separator</code>.
 <br>
 <br>
@@ -5577,7 +5577,7 @@ hexadecimal, in which case a <code>radix</code> of <code>16</code> is used.
 </div>
 <div>
 <h3 id="startCase"><a href="#startCase" class="fa fa-link"></a><code>_.startCase([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14629">source</a> <a href="https://www.npmjs.com/package/lodash.startcase">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14697">source</a> <a href="https://www.npmjs.com/package/lodash.startcase">npm package</a></p>
 <p>Converts <code>string</code> to
 <a href="https://en.wikipedia.org/wiki/Letter_case#Stylistic_or_specialised_usage">start case</a>.</p>
 <h4>Since</h4>
@@ -5594,7 +5594,7 @@ hexadecimal, in which case a <code>radix</code> of <code>16</code> is used.
 </div>
 <div>
 <h3 id="startsWith"><a href="#startsWith" class="fa fa-link"></a><code>_.startsWith([string=&apos;&apos;], [target], [position=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14656">source</a> <a href="https://www.npmjs.com/package/lodash.startswith">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14724">source</a> <a href="https://www.npmjs.com/package/lodash.startswith">npm package</a></p>
 <p>Checks if <code>string</code> starts with the given target string.</p>
 <h4>Since</h4>
 <p>3.0.0</p>
@@ -5612,7 +5612,7 @@ hexadecimal, in which case a <code>radix</code> of <code>16</code> is used.
 </div>
 <div>
 <h3 id="template"><a href="#template" class="fa fa-link"></a><code>_.template([string=&apos;&apos;], [options={}])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14770">source</a> <a href="https://www.npmjs.com/package/lodash.template">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14838">source</a> <a href="https://www.npmjs.com/package/lodash.template">npm package</a></p>
 <p>Creates a compiled template function that can interpolate data properties
 in &quot;interpolate&quot; delimiters, HTML-escape interpolated data properties in
 &quot;escape&quot; delimiters, and execute JavaScript in &quot;evaluate&quot; delimiters. Data
@@ -5652,7 +5652,7 @@ For more information on Chrome extension sandboxes see
 </div>
 <div>
 <h3 id="toLower"><a href="#toLower" class="fa fa-link"></a><code>_.toLower([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14904">source</a> <a href="https://www.npmjs.com/package/lodash.tolower">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L14976">source</a> <a href="https://www.npmjs.com/package/lodash.tolower">npm package</a></p>
 <p>Converts <code>string</code>, as a whole, to lower case just like
 <a href="https://mdn.io/toLowerCase">String#toLowerCase</a>.</p>
 <h4>Since</h4>
@@ -5669,7 +5669,7 @@ For more information on Chrome extension sandboxes see
 </div>
 <div>
 <h3 id="toUpper"><a href="#toUpper" class="fa fa-link"></a><code>_.toUpper([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14929">source</a> <a href="https://www.npmjs.com/package/lodash.toupper">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15001">source</a> <a href="https://www.npmjs.com/package/lodash.toupper">npm package</a></p>
 <p>Converts <code>string</code>, as a whole, to upper case just like
 <a href="https://mdn.io/toUpperCase">String#toUpperCase</a>.</p>
 <h4>Since</h4>
@@ -5686,7 +5686,7 @@ For more information on Chrome extension sandboxes see
 </div>
 <div>
 <h3 id="trim"><a href="#trim" class="fa fa-link"></a><code>_.trim([string=&apos;&apos;], [chars=whitespace])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14955">source</a> <a href="https://www.npmjs.com/package/lodash.trim">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15027">source</a> <a href="https://www.npmjs.com/package/lodash.trim">npm package</a></p>
 <p>Removes leading and trailing whitespace or specified characters from <code>string</code>.</p>
 <h4>Since</h4>
 <p>3.0.0</p>
@@ -5703,7 +5703,7 @@ For more information on Chrome extension sandboxes see
 </div>
 <div>
 <h3 id="trimEnd"><a href="#trimEnd" class="fa fa-link"></a><code>_.trimEnd([string=&apos;&apos;], [chars=whitespace])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14990">source</a> <a href="https://www.npmjs.com/package/lodash.trimend">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15062">source</a> <a href="https://www.npmjs.com/package/lodash.trimend">npm package</a></p>
 <p>Removes trailing whitespace or specified characters from <code>string</code>.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -5720,7 +5720,7 @@ For more information on Chrome extension sandboxes see
 </div>
 <div>
 <h3 id="trimStart"><a href="#trimStart" class="fa fa-link"></a><code>_.trimStart([string=&apos;&apos;], [chars=whitespace])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15023">source</a> <a href="https://www.npmjs.com/package/lodash.trimstart">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15095">source</a> <a href="https://www.npmjs.com/package/lodash.trimstart">npm package</a></p>
 <p>Removes leading whitespace or specified characters from <code>string</code>.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -5737,7 +5737,7 @@ For more information on Chrome extension sandboxes see
 </div>
 <div>
 <h3 id="truncate"><a href="#truncate" class="fa fa-link"></a><code>_.truncate([string=&apos;&apos;], [options={}])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15074">source</a> <a href="https://www.npmjs.com/package/lodash.truncate">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15146">source</a> <a href="https://www.npmjs.com/package/lodash.truncate">npm package</a></p>
 <p>Truncates <code>string</code> if it&apos;s longer than the given maximum string length.
 The last characters of the truncated string are replaced with the omission
 string which defaults to &quot;...&quot;.</p>
@@ -5759,7 +5759,7 @@ string which defaults to &quot;...&quot;.</p>
 </div>
 <div>
 <h3 id="unescape"><a href="#unescape" class="fa fa-link"></a><code>_.unescape([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15149">source</a> <a href="https://www.npmjs.com/package/lodash.unescape">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15221">source</a> <a href="https://www.npmjs.com/package/lodash.unescape">npm package</a></p>
 <p>The inverse of <a href="#escape"><code>_.escape</code></a>; this method converts the HTML entities
 <code>&amp;amp;</code>, <code>&amp;lt;</code>, <code>&amp;gt;</code>, <code>&amp;quot;</code>, and <code>&amp;#39;</code> in <code>string</code> to
 their corresponding characters.
@@ -5781,7 +5781,7 @@ HTML entities use a third-party library like <a href="https://mths.be/he"><em>he
 </div>
 <div>
 <h3 id="upperCase"><a href="#upperCase" class="fa fa-link"></a><code>_.upperCase([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15176">source</a> <a href="https://www.npmjs.com/package/lodash.uppercase">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15248">source</a> <a href="https://www.npmjs.com/package/lodash.uppercase">npm package</a></p>
 <p>Converts <code>string</code>, as space separated words, to upper case.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -5797,7 +5797,7 @@ HTML entities use a third-party library like <a href="https://mths.be/he"><em>he
 </div>
 <div>
 <h3 id="upperFirst"><a href="#upperFirst" class="fa fa-link"></a><code>_.upperFirst([string=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15197">source</a> <a href="https://www.npmjs.com/package/lodash.upperfirst">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15269">source</a> <a href="https://www.npmjs.com/package/lodash.upperfirst">npm package</a></p>
 <p>Converts the first character of <code>string</code> to upper case.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -5813,7 +5813,7 @@ HTML entities use a third-party library like <a href="https://mths.be/he"><em>he
 </div>
 <div>
 <h3 id="words"><a href="#words" class="fa fa-link"></a><code>_.words([string=&apos;&apos;], [pattern])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15218">source</a> <a href="https://www.npmjs.com/package/lodash.words">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15290">source</a> <a href="https://www.npmjs.com/package/lodash.words">npm package</a></p>
 <p>Splits <code>string</code> into an array of its words.</p>
 <h4>Since</h4>
 <p>3.0.0</p>
@@ -5833,7 +5833,7 @@ HTML entities use a third-party library like <a href="https://mths.be/he"><em>he
 <h2><code>&#x201C;Util&#x201D; Methods</code></h2>
 <div>
 <h3 id="attempt"><a href="#attempt" class="fa fa-link"></a><code>_.attempt(func, [args])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15252">source</a> <a href="https://www.npmjs.com/package/lodash.attempt">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15324">source</a> <a href="https://www.npmjs.com/package/lodash.attempt">npm package</a></p>
 <p>Attempts to invoke <code>func</code>, returning either the result or the caught error
 object. Any additional arguments are provided to <code>func</code> when it&apos;s invoked.</p>
 <h4>Since</h4>
@@ -5851,7 +5851,7 @@ object. Any additional arguments are provided to <code>func</code> when it&apos;
 </div>
 <div>
 <h3 id="bindAll"><a href="#bindAll" class="fa fa-link"></a><code>_.bindAll(object, methodNames)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15286">source</a> <a href="https://www.npmjs.com/package/lodash.bindall">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15358">source</a> <a href="https://www.npmjs.com/package/lodash.bindall">npm package</a></p>
 <p>Binds methods of an object to the object itself, overwriting the existing
 method.
 <br>
@@ -5872,7 +5872,7 @@ method.
 </div>
 <div>
 <h3 id="cond"><a href="#cond" class="fa fa-link"></a><code>_.cond(pairs)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15323">source</a> <a href="https://www.npmjs.com/package/lodash.cond">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15395">source</a> <a href="https://www.npmjs.com/package/lodash.cond">npm package</a></p>
 <p>Creates a function that iterates over <code>pairs</code> and invokes the corresponding
 function of the first predicate to return truthy. The predicate-function
 pairs are invoked with the <code>this</code> binding and arguments of the created
@@ -5891,7 +5891,7 @@ function.</p>
 </div>
 <div>
 <h3 id="conforms"><a href="#conforms" class="fa fa-link"></a><code>_.conforms(source)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15369">source</a> <a href="https://www.npmjs.com/package/lodash.conforms">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15441">source</a> <a href="https://www.npmjs.com/package/lodash.conforms">npm package</a></p>
 <p>Creates a function that invokes the predicate properties of <code>source</code> with
 the corresponding property values of a given object, returning <code>true</code> if
 all predicates return truthy, else <code>false</code>.
@@ -5913,7 +5913,7 @@ all predicates return truthy, else <code>false</code>.
 </div>
 <div>
 <h3 id="constant"><a href="#constant" class="fa fa-link"></a><code>_.constant(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15392">source</a> <a href="https://www.npmjs.com/package/lodash.constant">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15464">source</a> <a href="https://www.npmjs.com/package/lodash.constant">npm package</a></p>
 <p>Creates a function that returns <code>value</code>.</p>
 <h4>Since</h4>
 <p>2.4.0</p>
@@ -5929,7 +5929,7 @@ all predicates return truthy, else <code>false</code>.
 </div>
 <div>
 <h3 id="defaultTo"><a href="#defaultTo" class="fa fa-link"></a><code>_.defaultTo(value, defaultValue)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15418">source</a> <a href="https://www.npmjs.com/package/lodash.defaultto">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15490">source</a> <a href="https://www.npmjs.com/package/lodash.defaultto">npm package</a></p>
 <p>Checks <code>value</code> to determine whether a default value should be returned in
 its place. The <code>defaultValue</code> is returned if <code>value</code> is <code>NaN</code>, <code>null</code>,
 or <code>undefined</code>.</p>
@@ -5948,7 +5948,7 @@ or <code>undefined</code>.</p>
 </div>
 <div>
 <h3 id="flow"><a href="#flow" class="fa fa-link"></a><code>_.flow([funcs])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15444">source</a> <a href="https://www.npmjs.com/package/lodash.flow">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15516">source</a> <a href="https://www.npmjs.com/package/lodash.flow">npm package</a></p>
 <p>Creates a function that returns the result of invoking the given functions
 with the <code>this</code> binding of the created function, where each successive
 invocation is supplied the return value of the previous.</p>
@@ -5966,7 +5966,7 @@ invocation is supplied the return value of the previous.</p>
 </div>
 <div>
 <h3 id="flowRight"><a href="#flowRight" class="fa fa-link"></a><code>_.flowRight([funcs])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15467">source</a> <a href="https://www.npmjs.com/package/lodash.flowright">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15539">source</a> <a href="https://www.npmjs.com/package/lodash.flowright">npm package</a></p>
 <p>This method is like <a href="#flow"><code>_.flow</code></a> except that it creates a function that
 invokes the given functions from right to left.</p>
 <h4>Since</h4>
@@ -5983,7 +5983,7 @@ invokes the given functions from right to left.</p>
 </div>
 <div>
 <h3 id="identity"><a href="#identity" class="fa fa-link"></a><code>_.identity(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15485">source</a> <a href="https://www.npmjs.com/package/lodash.identity">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15557">source</a> <a href="https://www.npmjs.com/package/lodash.identity">npm package</a></p>
 <p>This method returns the first argument it receives.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -5999,7 +5999,7 @@ invokes the given functions from right to left.</p>
 </div>
 <div>
 <h3 id="iteratee"><a href="#iteratee" class="fa fa-link"></a><code>_.iteratee([func=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15531">source</a> <a href="https://www.npmjs.com/package/lodash.iteratee">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15603">source</a> <a href="https://www.npmjs.com/package/lodash.iteratee">npm package</a></p>
 <p>Creates a function that invokes <code>func</code> with the arguments of the created
 function. If <code>func</code> is a property name, the created function returns the
 property value for a given element. If <code>func</code> is an array or object, the
@@ -6019,7 +6019,7 @@ source properties, otherwise it returns <code>false</code>.</p>
 </div>
 <div>
 <h3 id="matches"><a href="#matches" class="fa fa-link"></a><code>_.matches(source)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15563">source</a> <a href="https://www.npmjs.com/package/lodash.matches">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15642">source</a> <a href="https://www.npmjs.com/package/lodash.matches">npm package</a></p>
 <p>Creates a function that performs a partial deep comparison between a given
 object and <code>source</code>, returning <code>true</code> if the given object has equivalent
 property values, else <code>false</code>.
@@ -6031,7 +6031,11 @@ partially applied.
 <br>
 Partial comparisons will match empty array and empty object <code>source</code>
 values against any array or object value, respectively. See <a href="#isEqual"><code>_.isEqual</code></a>
-for a list of supported value comparisons.</p>
+for a list of supported value comparisons.
+<br>
+<br>
+<strong>Note:</strong> Multiple values can be checked by combining several matchers
+using <a href="#overSome"><code>_.overSome</code></a></p>
 <h4>Since</h4>
 <p>3.0.0</p>
 <h4>Arguments</h4>
@@ -6041,12 +6045,12 @@ for a list of supported value comparisons.</p>
 <h4>Returns</h4>
 <p><em>(Function)</em>: Returns the new spec function.</p>
 <h4>Example</h4>
-<div class="highlight js"><pre><div><span class="type">var</span>&#xA0;objects&#xA0;=&#xA0;[</div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">1</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;b&apos;</span>:&#xA0;<span class="numeric">2</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;c&apos;</span>:&#xA0;<span class="numeric">3</span>&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">4</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;b&apos;</span>:&#xA0;<span class="numeric">5</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;c&apos;</span>:&#xA0;<span class="numeric">6</span>&#xA0;}</div><div>];</div><div>&#xA0;</div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(objects<span class="delimiter">,</span>&#xA0;_<span class="delimiter method">.</span><span class="name">matches</span>({&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">4</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;c&apos;</span>:&#xA0;<span class="numeric">6</span>&#xA0;}));</div><div><span class="comment">//&#xA0;=&gt;&#xA0;[{&#xA0;&apos;a&apos;:&#xA0;4,&#xA0;&apos;b&apos;:&#xA0;5,&#xA0;&apos;c&apos;:&#xA0;6&#xA0;}]</span></div></pre></div>
+<div class="highlight js"><pre><div><span class="type">var</span>&#xA0;objects&#xA0;=&#xA0;[</div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">1</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;b&apos;</span>:&#xA0;<span class="numeric">2</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;c&apos;</span>:&#xA0;<span class="numeric">3</span>&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">4</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;b&apos;</span>:&#xA0;<span class="numeric">5</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;c&apos;</span>:&#xA0;<span class="numeric">6</span>&#xA0;}</div><div>];</div><div>&#xA0;</div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(objects<span class="delimiter">,</span>&#xA0;_<span class="delimiter method">.</span><span class="name">matches</span>({&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">4</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;c&apos;</span>:&#xA0;<span class="numeric">6</span>&#xA0;}));</div><div><span class="comment">//&#xA0;=&gt;&#xA0;[{&#xA0;&apos;a&apos;:&#xA0;4,&#xA0;&apos;b&apos;:&#xA0;5,&#xA0;&apos;c&apos;:&#xA0;6&#xA0;}]</span></div><div>&#xA0;</div><div><span class="comment">//&#xA0;Checking&#xA0;for&#xA0;several&#xA0;possible&#xA0;values</span></div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(objects<span class="delimiter">,</span>&#xA0;_<span class="delimiter method">.</span><span class="name">overSome</span>([_<span class="delimiter method">.</span><span class="name">matches</span>({&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">1</span>&#xA0;})<span class="delimiter">,</span>&#xA0;_<span class="delimiter method">.</span><span class="name">matches</span>({&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">4</span>&#xA0;})]));</div><div><span class="comment">//&#xA0;=&gt;&#xA0;[{&#xA0;&apos;a&apos;:&#xA0;1,&#xA0;&apos;b&apos;:&#xA0;2,&#xA0;&apos;c&apos;:&#xA0;3&#xA0;},&#xA0;{&#xA0;&apos;a&apos;:&#xA0;4,&#xA0;&apos;b&apos;:&#xA0;5,&#xA0;&apos;c&apos;:&#xA0;6&#xA0;}]</span></div></pre></div>
 
 </div>
 <div>
 <h3 id="matchesProperty"><a href="#matchesProperty" class="fa fa-link"></a><code>_.matchesProperty(path, srcValue)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15593">source</a> <a href="https://www.npmjs.com/package/lodash.matchesproperty">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15679">source</a> <a href="https://www.npmjs.com/package/lodash.matchesproperty">npm package</a></p>
 <p>Creates a function that performs a partial deep comparison between the
 value at <code>path</code> of a given object to <code>srcValue</code>, returning <code>true</code> if the
 object value is equivalent, else <code>false</code>.
@@ -6054,7 +6058,11 @@ object value is equivalent, else <code>false</code>.
 <br>
 <strong>Note:</strong> Partial comparisons will match empty array and empty object
 <code>srcValue</code> values against any array or object value, respectively. See
-<a href="#isEqual"><code>_.isEqual</code></a> for a list of supported value comparisons.</p>
+<a href="#isEqual"><code>_.isEqual</code></a> for a list of supported value comparisons.
+<br>
+<br>
+<strong>Note:</strong> Multiple values can be checked by combining several matchers
+using <a href="#overSome"><code>_.overSome</code></a></p>
 <h4>Since</h4>
 <p>3.2.0</p>
 <h4>Arguments</h4>
@@ -6065,12 +6073,12 @@ object value is equivalent, else <code>false</code>.
 <h4>Returns</h4>
 <p><em>(Function)</em>: Returns the new spec function.</p>
 <h4>Example</h4>
-<div class="highlight js"><pre><div><span class="type">var</span>&#xA0;objects&#xA0;=&#xA0;[</div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">1</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;b&apos;</span>:&#xA0;<span class="numeric">2</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;c&apos;</span>:&#xA0;<span class="numeric">3</span>&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">4</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;b&apos;</span>:&#xA0;<span class="numeric">5</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;c&apos;</span>:&#xA0;<span class="numeric">6</span>&#xA0;}</div><div>];</div><div>&#xA0;</div><div>_<span class="delimiter method">.</span><span class="support">find</span>(objects<span class="delimiter">,</span>&#xA0;_<span class="delimiter method">.</span><span class="name">matchesProperty</span>(<span class="string">&apos;a&apos;</span><span class="delimiter">,</span>&#xA0;<span class="numeric">4</span>));</div><div><span class="comment">//&#xA0;=&gt;&#xA0;{&#xA0;&apos;a&apos;:&#xA0;4,&#xA0;&apos;b&apos;:&#xA0;5,&#xA0;&apos;c&apos;:&#xA0;6&#xA0;}</span></div></pre></div>
+<div class="highlight js"><pre><div><span class="type">var</span>&#xA0;objects&#xA0;=&#xA0;[</div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">1</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;b&apos;</span>:&#xA0;<span class="numeric">2</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;c&apos;</span>:&#xA0;<span class="numeric">3</span>&#xA0;}<span class="delimiter">,</span></div><div>&#xA0;&#xA0;{&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">4</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;b&apos;</span>:&#xA0;<span class="numeric">5</span><span class="delimiter">,</span>&#xA0;<span class="string">&apos;c&apos;</span>:&#xA0;<span class="numeric">6</span>&#xA0;}</div><div>];</div><div>&#xA0;</div><div>_<span class="delimiter method">.</span><span class="support">find</span>(objects<span class="delimiter">,</span>&#xA0;_<span class="delimiter method">.</span><span class="name">matchesProperty</span>(<span class="string">&apos;a&apos;</span><span class="delimiter">,</span>&#xA0;<span class="numeric">4</span>));</div><div><span class="comment">//&#xA0;=&gt;&#xA0;{&#xA0;&apos;a&apos;:&#xA0;4,&#xA0;&apos;b&apos;:&#xA0;5,&#xA0;&apos;c&apos;:&#xA0;6&#xA0;}</span></div><div>&#xA0;</div><div><span class="comment">//&#xA0;Checking&#xA0;for&#xA0;several&#xA0;possible&#xA0;values</span></div><div>_<span class="delimiter method">.</span><span class="name">filter</span>(objects<span class="delimiter">,</span>&#xA0;_<span class="delimiter method">.</span><span class="name">overSome</span>([_<span class="delimiter method">.</span><span class="name">matchesProperty</span>(<span class="string">&apos;a&apos;</span><span class="delimiter">,</span>&#xA0;<span class="numeric">1</span>)<span class="delimiter">,</span>&#xA0;_<span class="delimiter method">.</span><span class="name">matchesProperty</span>(<span class="string">&apos;a&apos;</span><span class="delimiter">,</span>&#xA0;<span class="numeric">4</span>)]));</div><div><span class="comment">//&#xA0;=&gt;&#xA0;[{&#xA0;&apos;a&apos;:&#xA0;1,&#xA0;&apos;b&apos;:&#xA0;2,&#xA0;&apos;c&apos;:&#xA0;3&#xA0;},&#xA0;{&#xA0;&apos;a&apos;:&#xA0;4,&#xA0;&apos;b&apos;:&#xA0;5,&#xA0;&apos;c&apos;:&#xA0;6&#xA0;}]</span></div></pre></div>
 
 </div>
 <div>
 <h3 id="method"><a href="#method" class="fa fa-link"></a><code>_.method(path, [args])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15621">source</a> <a href="https://www.npmjs.com/package/lodash.method">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15707">source</a> <a href="https://www.npmjs.com/package/lodash.method">npm package</a></p>
 <p>Creates a function that invokes the method at <code>path</code> of a given object.
 Any additional arguments are provided to the invoked method.</p>
 <h4>Since</h4>
@@ -6088,7 +6096,7 @@ Any additional arguments are provided to the invoked method.</p>
 </div>
 <div>
 <h3 id="methodOf"><a href="#methodOf" class="fa fa-link"></a><code>_.methodOf(object, [args])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15650">source</a> <a href="https://www.npmjs.com/package/lodash.methodof">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15736">source</a> <a href="https://www.npmjs.com/package/lodash.methodof">npm package</a></p>
 <p>The opposite of <a href="#method"><code>_.method</code></a>; this method creates a function that invokes
 the method at a given path of <code>object</code>. Any additional arguments are
 provided to the invoked method.</p>
@@ -6107,7 +6115,7 @@ provided to the invoked method.</p>
 </div>
 <div>
 <h3 id="mixin"><a href="#mixin" class="fa fa-link"></a><code>_.mixin([object=lodash], source, [options={}])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15692">source</a> <a href="https://www.npmjs.com/package/lodash.mixin">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15778">source</a> <a href="https://www.npmjs.com/package/lodash.mixin">npm package</a></p>
 <p>Adds all own enumerable string keyed function properties of a source
 object to the destination object. If <code>object</code> is a function, then methods
 are added to its prototype as well.
@@ -6132,7 +6140,7 @@ avoid conflicts caused by modifying the original.</p>
 </div>
 <div>
 <h3 id="noConflict"><a href="#noConflict" class="fa fa-link"></a><code>_.noConflict()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15741">source</a> <a href="https://www.npmjs.com/package/lodash.noconflict">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15827">source</a> <a href="https://www.npmjs.com/package/lodash.noconflict">npm package</a></p>
 <p>Reverts the <code>_</code> variable to its previous value and returns a reference to
 the <code>lodash</code> function.</p>
 <h4>Since</h4>
@@ -6145,7 +6153,7 @@ the <code>lodash</code> function.</p>
 </div>
 <div>
 <h3 id="noop"><a href="#noop" class="fa fa-link"></a><code>_.noop()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15760">source</a> <a href="https://www.npmjs.com/package/lodash.noop">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15846">source</a> <a href="https://www.npmjs.com/package/lodash.noop">npm package</a></p>
 <p>This method returns <code>undefined</code>.</p>
 <h4>Since</h4>
 <p>2.3.0</p>
@@ -6155,7 +6163,7 @@ the <code>lodash</code> function.</p>
 </div>
 <div>
 <h3 id="nthArg"><a href="#nthArg" class="fa fa-link"></a><code>_.nthArg([n=0])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15784">source</a> <a href="https://www.npmjs.com/package/lodash.ntharg">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15870">source</a> <a href="https://www.npmjs.com/package/lodash.ntharg">npm package</a></p>
 <p>Creates a function that gets the argument at index <code>n</code>. If <code>n</code> is negative,
 the nth argument from the end is returned.</p>
 <h4>Since</h4>
@@ -6172,7 +6180,7 @@ the nth argument from the end is returned.</p>
 </div>
 <div>
 <h3 id="over"><a href="#over" class="fa fa-link"></a><code>_.over([iteratees=[_.identity]])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15809">source</a> <a href="https://www.npmjs.com/package/lodash.over">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15895">source</a> <a href="https://www.npmjs.com/package/lodash.over">npm package</a></p>
 <p>Creates a function that invokes <code>iteratees</code> with the arguments it receives
 and returns their results.</p>
 <h4>Since</h4>
@@ -6189,9 +6197,14 @@ and returns their results.</p>
 </div>
 <div>
 <h3 id="overEvery"><a href="#overEvery" class="fa fa-link"></a><code>_.overEvery([predicates=[_.identity]])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15835">source</a> <a href="https://www.npmjs.com/package/lodash.overevery">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15925">source</a> <a href="https://www.npmjs.com/package/lodash.overevery">npm package</a></p>
 <p>Creates a function that checks if <strong>all</strong> of the <code>predicates</code> return
-truthy when invoked with the arguments it receives.</p>
+truthy when invoked with the arguments it receives.
+<br>
+<br>
+Following shorthands are possible for providing predicates.
+Pass an <code>Object</code> and it will be used as an parameter for <a href="#matches"><code>_.matches</code></a> to create the predicate.
+Pass an <code>Array</code> of parameters for <a href="#matchesProperty"><code>_.matchesProperty</code></a> and the predicate will be created using them.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
 <h4>Arguments</h4>
@@ -6206,9 +6219,14 @@ truthy when invoked with the arguments it receives.</p>
 </div>
 <div>
 <h3 id="overSome"><a href="#overSome" class="fa fa-link"></a><code>_.overSome([predicates=[_.identity]])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15861">source</a> <a href="https://www.npmjs.com/package/lodash.oversome">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15958">source</a> <a href="https://www.npmjs.com/package/lodash.oversome">npm package</a></p>
 <p>Creates a function that checks if <strong>any</strong> of the <code>predicates</code> return
-truthy when invoked with the arguments it receives.</p>
+truthy when invoked with the arguments it receives.
+<br>
+<br>
+Following shorthands are possible for providing predicates.
+Pass an <code>Object</code> and it will be used as an parameter for <a href="#matches"><code>_.matches</code></a> to create the predicate.
+Pass an <code>Array</code> of parameters for <a href="#matchesProperty"><code>_.matchesProperty</code></a> and the predicate will be created using them.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
 <h4>Arguments</h4>
@@ -6218,12 +6236,12 @@ truthy when invoked with the arguments it receives.</p>
 <h4>Returns</h4>
 <p><em>(Function)</em>: Returns the new function.</p>
 <h4>Example</h4>
-<div class="highlight js"><pre><div><span class="type">var</span>&#xA0;func&#xA0;=&#xA0;_<span class="delimiter method">.</span><span class="name">overSome</span>([<span class="support">Boolean</span><span class="delimiter">,</span>&#xA0;isFinite]);</div><div>&#xA0;</div><div><span class="name">func</span>(<span class="string">&apos;1&apos;</span>);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;true</span></div><div>&#xA0;</div><div><span class="name">func</span>(null);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;true</span></div><div>&#xA0;</div><div><span class="name">func</span>(NaN);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;false</span></div></pre></div>
+<div class="highlight js"><pre><div><span class="type">var</span>&#xA0;func&#xA0;=&#xA0;_<span class="delimiter method">.</span><span class="name">overSome</span>([<span class="support">Boolean</span><span class="delimiter">,</span>&#xA0;isFinite]);</div><div>&#xA0;</div><div><span class="name">func</span>(<span class="string">&apos;1&apos;</span>);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;true</span></div><div>&#xA0;</div><div><span class="name">func</span>(null);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;true</span></div><div>&#xA0;</div><div><span class="name">func</span>(NaN);</div><div><span class="comment">//&#xA0;=&gt;&#xA0;false</span></div><div>&#xA0;</div><div><span class="type">var</span>&#xA0;matchesFunc&#xA0;=&#xA0;_<span class="delimiter method">.</span><span class="name">overSome</span>([{&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">1</span>&#xA0;}<span class="delimiter">,</span>&#xA0;{&#xA0;<span class="string">&apos;a&apos;</span>:&#xA0;<span class="numeric">2</span>&#xA0;}])</div><div><span class="type">var</span>&#xA0;matchesPropertyFunc&#xA0;=&#xA0;_<span class="delimiter method">.</span><span class="name">overSome</span>([[<span class="string">&apos;a&apos;</span><span class="delimiter">,</span>&#xA0;<span class="numeric">1</span>]<span class="delimiter">,</span>&#xA0;[<span class="string">&apos;a&apos;</span><span class="delimiter">,</span>&#xA0;<span class="numeric">2</span>]])</div></pre></div>
 
 </div>
 <div>
 <h3 id="property"><a href="#property" class="fa fa-link"></a><code>_.property(path)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15885">source</a> <a href="https://www.npmjs.com/package/lodash.property">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L15982">source</a> <a href="https://www.npmjs.com/package/lodash.property">npm package</a></p>
 <p>Creates a function that returns the value at <code>path</code> of a given object.</p>
 <h4>Since</h4>
 <p>2.4.0</p>
@@ -6239,7 +6257,7 @@ truthy when invoked with the arguments it receives.</p>
 </div>
 <div>
 <h3 id="propertyOf"><a href="#propertyOf" class="fa fa-link"></a><code>_.propertyOf(object)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15910">source</a> <a href="https://www.npmjs.com/package/lodash.propertyof">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16007">source</a> <a href="https://www.npmjs.com/package/lodash.propertyof">npm package</a></p>
 <p>The opposite of <a href="#property"><code>_.property</code></a>; this method creates a function that returns
 the value at a given path of <code>object</code>.</p>
 <h4>Since</h4>
@@ -6256,7 +6274,7 @@ the value at a given path of <code>object</code>.</p>
 </div>
 <div>
 <h3 id="range"><a href="#range" class="fa fa-link"></a><code>_.range([start=0], end, [step=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15957">source</a> <a href="https://www.npmjs.com/package/lodash.range">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16054">source</a> <a href="https://www.npmjs.com/package/lodash.range">npm package</a></p>
 <p>Creates an array of numbers <em>(positive and/or negative)</em> progressing from
 <code>start</code> up to, but not including, <code>end</code>. A step of <code>-1</code> is used if a negative
 <code>start</code> is specified without an <code>end</code> or <code>step</code>. If <code>end</code> is not specified,
@@ -6281,7 +6299,7 @@ floating-point values which can produce unexpected results.</p>
 </div>
 <div>
 <h3 id="rangeRight"><a href="#rangeRight" class="fa fa-link"></a><code>_.rangeRight([start=0], end, [step=1])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L15995">source</a> <a href="https://www.npmjs.com/package/lodash.rangeright">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16092">source</a> <a href="https://www.npmjs.com/package/lodash.rangeright">npm package</a></p>
 <p>This method is like <a href="#range"><code>_.range</code></a> except that it populates values in
 descending order.</p>
 <h4>Since</h4>
@@ -6300,7 +6318,7 @@ descending order.</p>
 </div>
 <div>
 <h3 id="runInContext"><a href="#runInContext" class="fa fa-link"></a><code>_.runInContext([context=root])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L1406">source</a> <a href="https://www.npmjs.com/package/lodash.runincontext">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L1448">source</a> <a href="https://www.npmjs.com/package/lodash.runincontext">npm package</a></p>
 <p>Create a new pristine <code>lodash</code> function using the <code>context</code> object.</p>
 <h4>Since</h4>
 <p>1.1.0</p>
@@ -6316,7 +6334,7 @@ descending order.</p>
 </div>
 <div>
 <h3 id="stubArray"><a href="#stubArray" class="fa fa-link"></a><code>_.stubArray()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16015">source</a> <a href="https://www.npmjs.com/package/lodash.stubarray">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16112">source</a> <a href="https://www.npmjs.com/package/lodash.stubarray">npm package</a></p>
 <p>This method returns a new empty array.</p>
 <h4>Since</h4>
 <p>4.13.0</p>
@@ -6328,7 +6346,7 @@ descending order.</p>
 </div>
 <div>
 <h3 id="stubFalse"><a href="#stubFalse" class="fa fa-link"></a><code>_.stubFalse()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16032">source</a> <a href="https://www.npmjs.com/package/lodash.stubfalse">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16129">source</a> <a href="https://www.npmjs.com/package/lodash.stubfalse">npm package</a></p>
 <p>This method returns <code>false</code>.</p>
 <h4>Since</h4>
 <p>4.13.0</p>
@@ -6340,7 +6358,7 @@ descending order.</p>
 </div>
 <div>
 <h3 id="stubObject"><a href="#stubObject" class="fa fa-link"></a><code>_.stubObject()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16054">source</a> <a href="https://www.npmjs.com/package/lodash.stubobject">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16151">source</a> <a href="https://www.npmjs.com/package/lodash.stubobject">npm package</a></p>
 <p>This method returns a new empty object.</p>
 <h4>Since</h4>
 <p>4.13.0</p>
@@ -6352,7 +6370,7 @@ descending order.</p>
 </div>
 <div>
 <h3 id="stubString"><a href="#stubString" class="fa fa-link"></a><code>_.stubString()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16071">source</a> <a href="https://www.npmjs.com/package/lodash.stubstring">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16168">source</a> <a href="https://www.npmjs.com/package/lodash.stubstring">npm package</a></p>
 <p>This method returns an empty string.</p>
 <h4>Since</h4>
 <p>4.13.0</p>
@@ -6364,7 +6382,7 @@ descending order.</p>
 </div>
 <div>
 <h3 id="stubTrue"><a href="#stubTrue" class="fa fa-link"></a><code>_.stubTrue()</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16088">source</a> <a href="https://www.npmjs.com/package/lodash.stubtrue">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16185">source</a> <a href="https://www.npmjs.com/package/lodash.stubtrue">npm package</a></p>
 <p>This method returns <code>true</code>.</p>
 <h4>Since</h4>
 <p>4.13.0</p>
@@ -6376,7 +6394,7 @@ descending order.</p>
 </div>
 <div>
 <h3 id="times"><a href="#times" class="fa fa-link"></a><code>_.times(n, [iteratee=_.identity])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16111">source</a> <a href="https://www.npmjs.com/package/lodash.times">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16208">source</a> <a href="https://www.npmjs.com/package/lodash.times">npm package</a></p>
 <p>Invokes the iteratee <code>n</code> times, returning an array of the results of
 each invocation. The iteratee is invoked with one argument; <em>(index)</em>.</p>
 <h4>Since</h4>
@@ -6394,7 +6412,7 @@ each invocation. The iteratee is invoked with one argument; <em>(index)</em>.</p
 </div>
 <div>
 <h3 id="toPath"><a href="#toPath" class="fa fa-link"></a><code>_.toPath(value)</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16146">source</a> <a href="https://www.npmjs.com/package/lodash.topath">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16243">source</a> <a href="https://www.npmjs.com/package/lodash.topath">npm package</a></p>
 <p>Converts <code>value</code> to a property path array.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -6410,7 +6428,7 @@ each invocation. The iteratee is invoked with one argument; <em>(index)</em>.</p
 </div>
 <div>
 <h3 id="uniqueId"><a href="#uniqueId" class="fa fa-link"></a><code>_.uniqueId([prefix=&apos;&apos;])</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16170">source</a> <a href="https://www.npmjs.com/package/lodash.uniqueid">npm package</a></p>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16267">source</a> <a href="https://www.npmjs.com/package/lodash.uniqueid">npm package</a></p>
 <p>Generates a unique ID. If <code>prefix</code> is given, the ID is appended to it.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -6428,14 +6446,14 @@ each invocation. The iteratee is invoked with one argument; <em>(index)</em>.</p
 <div>
 <h2><code>Properties</code></h2>
 <div>
-<h3 id="VERSION"><a href="#VERSION" class="fa fa-link"></a><code>_.VERSION</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L16861">source</a></p>
+<h3 id="VERSION"><a href="#VERSION" class="fa fa-link"></a><a href="#VERSION"><code>_.VERSION</code></a></h3>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L16958)
 <p>(string): The semantic version number.</p>
 
 </div>
 <div>
-  <h3 id="templateSettings"><a href="#templateSettings" class="fa fa-link"></a><code>_.templateSettings</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L1717">source</a> <a href="https://www.npmjs.com/package/lodash.templatesettings">npm package</a></p>
+<h3 id="templateSettings"><a href="#templateSettings" class="fa fa-link"></a><a href="#templateSettings"><code>_.templateSettings</code></a></h3>
+<p><a href="https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L1759">source</a> <a href="https://www.npmjs.com/package/lodash.templatesettings">npm package</a></p>
 <p>(Object): By default, the template delimiters used by lodash are like those in
 embedded Ruby <em>(ERB)</em> as well as ES2015 template strings. Change the
 following template settings to use alternative delimiters.</p>
@@ -6443,31 +6461,31 @@ following template settings to use alternative delimiters.</p>
 </div>
 <div>
 <h3 id="templateSettings-escape"><a href="#templateSettings-escape" class="fa fa-link"></a><code>_.templateSettings.escape</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L1725">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L1767)
 <p>(RegExp): Used to detect <code>data</code> property values to be HTML-escaped.</p>
 
 </div>
 <div>
 <h3 id="templateSettings-evaluate"><a href="#templateSettings-evaluate" class="fa fa-link"></a><code>_.templateSettings.evaluate</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L1733">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L1775)
 <p>(RegExp): Used to detect code to be evaluated.</p>
 
 </div>
 <div>
 <h3 id="templateSettings-imports"><a href="#templateSettings-imports" class="fa fa-link"></a><code>_.templateSettings.imports</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L1757">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L1799)
 <p>(Object): Used to import variables into the compiled template.</p>
 
 </div>
 <div>
 <h3 id="templateSettings-interpolate"><a href="#templateSettings-interpolate" class="fa fa-link"></a><code>_.templateSettings.interpolate</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L1741">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L1783)
 <p>(RegExp): Used to detect <code>data</code> property values to inject.</p>
 
 </div>
 <div>
 <h3 id="templateSettings-variable"><a href="#templateSettings-variable" class="fa fa-link"></a><code>_.templateSettings.variable</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L1749">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L1791)
 <p>(string): Used to reference the data object in the template text.</p>
 
 </div>
@@ -6476,7 +6494,7 @@ following template settings to use alternative delimiters.</p>
 <h2><code>Methods</code></h2>
 <div>
 <h3 id="templateSettings-imports-_"><a href="#templateSettings-imports-_" class="fa fa-link"></a><code>_.templateSettings.imports._</code></h3>
-<p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L1765">source</a></p>
+[source](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L1807)
 <p>A reference to the <code>lodash</code> function.</p>
 
 </div>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp-sequence": "^0.4.6",
     "gulp-uglify": "^3.0.0",
     "js-yaml": "^3.8.4",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "node-fetch": "^1.7.1",
     "pump": "^1.0.2",
     "sri-toolbox": "~0.2.0",


### PR DESCRIPTION
I figured out how the docs are meant to be built.

From the lodash main repo, follow these directions:
https://gist.github.com/jonchurch/d0f641e9395a34afe35c9ab4043f378a
<details><summary>((reproduced instructions for posterity...)</summary>
# Building Lodash Documentation HTML

## Steps

```bash
# 1. Switch to Node 11
nvm use 11

# 2. Install dependencies (if not done yet)
npm install

# 3. Build docs
npm run doc:sitehtml

# Output: doc/4.17.21.html
```

## Why Node 11?
`oniguruma@6.2.1` (used by marky-markdown) is incompatible with modern Node.js due to old `nan@^2.0.9` and V8 API changes. Node 11 is the newest version that works.

## If you have `ignore-scripts=true` in `~/.npmrc`

Check if you have it enabled:
```bash
npm config get ignore-scripts
```

If it returns `true`, use these commands instead:

```bash
# 1. Switch to Node 11
nvm use 11

# 2. Manually build oniguruma (one-time)
cd node_modules/oniguruma && npx node-gyp@8 rebuild && cd ../..

# 3. Build docs directly
node lib/main/build-doc site && node lib/main/build-site

# Output: doc/4.17.21.html
```

</details>

to generate an html document

then copy that over into this repo's doc dir

```sh
# from the lodash main dir after above step
cp doc/4.17.21.html ../lodash.com/docs/4.17.21.temp.html
cd ../lodash.com # come back to the website repo

# for my own mollifaction I wanted a git mv to keep the diff history simple
git mv docs/4.17.15.html docs/4.17.21.html # rename the old docs to the new docs before overwrite
git add docs/4.17.21.html && git commit -m 'rename old docs to new docs'

mv docs/4.17.21.temp.html docs/4.17.21.html
```

then update to the latest version of lodash, telling the site what the latest version is:

```sh
npm i -D lodash@4.17.21

# pass the latest version string into this script to update config for the site build
npm run build:config 4.17.21
npm run build
```

And that brings us to wherew we are now in this PR