### PR TITLE
add back crossorigin for font preload

### DIFF
--- a/_headers
+++ b/_headers
@@ -102,7 +102,7 @@ Add resource hints for site-wide font faces.
   {% for style in family[1] %}
     {% for href in style[1] %}
       {% if href contains '.woff2' %}
-        {% capture hint %}<{{ href }}>; rel=preload; as=font; pr=1.0{% endcapture %}
+        {% capture hint %}<{{ href }}>; rel=preload; as=font; pr=1.0; crossorigin{% endcapture %}
         {% assign all = all | push:hint %}
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
font-face in the browser will always fetch via crossorigin=anonymous for fonts, TIL. 

So the preload needs to have crossorigin to match that despite us serving them from our origin

follow on from #304 