### PR TITLE
fix: searchbar input should always allow updates when input changes

### DIFF
--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -248,8 +248,8 @@
     },
 
     'shouldComponentUpdate': function(nextProps, nextState) {
-      return (this.state.searchFound || nextState.searchFound) &&
-        (normalize(this.state.searchValue) !== normalize(nextState.searchValue) ||
+      return this.state.searchValue !== nextState.searchValue ||
+        ((this.state.searchFound || nextState.searchFound) &&
           !_.isEqual(this.state.content, nextState.content))
     },
 


### PR DESCRIPTION
previously in shouldComponentUpdate we did not allow the controlled input component to update unless it meaningfully impacted the search results, which locked folks out of updating their search  term in cases where they had pasted in something, and deleting a character would not change the search result.

Dropped normalize bc we want to allow the input to stay responsive, even if the user's change would net out to the same input after normalization

closes https://github.com/lodash/lodash.com/issues/225


## Before:
https://github.com/user-attachments/assets/78b5f436-8ea9-4b88-b37e-a501f36780a6

## After:
https://github.com/user-attachments/assets/97c51e1c-780f-4521-86ea-20989f8683a2

