### PR TITLE
Add CSP style-src-attr for Carbon Ads

### DIFF
--- a/_headers
+++ b/_headers
@@ -61,6 +61,13 @@ csp:
     "'self'",
     'cdn.jsdelivr.net'
   ]
+  # Allow inline style attributes for Carbon Ads dynamic branding colors.
+  # Dynamic hex values (e.g., style="background: #ABC123") cannot be hashed
+  # since they change per ad impression. Using style-src-attr instead of
+  # style-src 'unsafe-inline' maintains protection for <style> blocks.
+  style-src-attr: [
+    "'unsafe-inline'"
+  ]
 hints:
   all: [
     '</sw.js>; rel=serviceworker',


### PR DESCRIPTION
Adds `style-src-attr 'unsafe-inline'` to the CSP configuration to allow Carbon Ads dynamic inline style attributes for branding colors.

This approach is more appropriate than adding `'unsafe-inline'` to `style-src` because it:
- Only permits inline style attributes (`<div style="...">`)
- Maintains protection against malicious `<style>` blocks
- Prevents unauthorized external stylesheets

Carbon Ads requires this because their ad server returns dynamic hex colors that change per impression, making hash-based CSP approaches infeasible.