### PR TITLE
fix: allow unsafe-inline for style-src-elem

### DIFF
--- a/_headers
+++ b/_headers
@@ -61,10 +61,14 @@ csp:
     "'self'",
     'cdn.jsdelivr.net'
   ]
-  # Allow inline style attributes for Carbon Ads dynamic branding colors.
-  # Dynamic hex values (e.g., style="background: #ABC123") cannot be hashed
-  # since they change per ad impression. Using style-src-attr instead of
-  # style-src 'unsafe-inline' maintains protection for <style> blocks.
+  # Carbon Ads applies dynamic branding colors that can't be hashed
+  # (they change per ad impression). Different ad formats use different methods:
+  # - cover format: injects <style> blocks (needs style-src-elem)
+  # - classic/responsive formats: uses style="" attributes (needs style-src-attr)
+  style-src-elem: [
+    "'self'",
+    "'unsafe-inline'",
+  ]
   style-src-attr: [
     "'unsafe-inline'"
   ]


### PR DESCRIPTION
will allow carbonads to create <style> blocks and inline style attributes

after #308, which targetted style-src-attr, I still saw the CSP error in the console, and the ads had broken CSS

Carbonads dynamically injects <style> tags for the `cover` ad format (style-src-elem), and uses inline style="..." attributes for the `classic` and `responsive` formats (style-src-attr). We are using the cover format.

ref: https://cdn.carbonads.com/carbon.js - see formats.cover(), formats.classic(), and formats.responsive()



## Before:
<img width="1055" height="287" alt="Screenshot 2025-12-15 at 6 17 07 PM" src="https://github.com/user-attachments/assets/49722f7f-afa5-4830-a77f-842734b78954" />

## After:
<img width="1055" height="287" alt="Screenshot 2025-12-15 at 6 17 58 PM" src="https://github.com/user-attachments/assets/e78cef6e-af26-461a-8f05-e0153cba2e91" />

