### PR TITLE
use the unminified versions on the site itself

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,16 +47,16 @@ sass:
 
 builds:
   *release:
-    href: https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js
-    integrity: sha384-H6KKS1H1WwuERMSm+54dYLzjg0fKqRK5ZRyASdbrI/lwrCc6bXEmtGYr5SwvP1pZ
+    href: https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.js
+    integrity: sha384-l3ZPesZ3gDMDOrzjEodAMRyQlQnAR6KFZN2hnIr+h8Y80fuKlD1jsjdxJpKr9XgP
 
   3.10.1:
-    href: https://cdn.jsdelivr.net/lodash/3.10.1/lodash.min.js
-    integrity: sha384-0BrUT26SU4JPtbvE/hI6oj4mbEXE32qhRoD51rUTB+QFrg6ViIceJR8op6FmEIA1
+    href: https://cdn.jsdelivr.net/lodash/3.10.1/lodash.js
+    integrity: sha384-Ttnm2H4AwtbOQtv9MhMtaiQESoDpIaUkjBikyZkN/ViPWCJPc0tN2Y+6LEB2xOvW
 
   2.4.2:
-    href: https://cdn.jsdelivr.net/npm/lodash@2.4.2/dist/lodash.min.js
-    integrity: sha384-i14qZ6FYmJXQABb+YG5tH4NXjKOLznxsr5jFsNiJNRcQ77978BoUif762EQyydgt
+    href: https://cdn.jsdelivr.net/npm/lodash@2.4.2/dist/lodash.js
+    integrity: sha384-dHt0zhrUjipKqd+3ge2VoJVUN8P9+oRNNwMgOYkwED5zlnhMR7bunXrmegF2MFJv
 
 font-face:
   fontawesome:


### PR DESCRIPTION
We load lodash itself via CDN on the docs site, to use it, but also to make it available in the console. We are using the minified version.

This PR closes #222, which pointed out that they like using lodash itself in the console when reading the docs, but wanted us to have the non-minified versions. 

Idk if they're doing `_.add.toString()` to dump the source or just reading from sources tab, but its a cute idea to ship a readable version to our own docs site.

Using unminified adds about ~69KB compressed to the size of the site (for the 4.x line)

This change is likely a day late and a dollar short, but it feels nice.