### PR TITLE
[New] Add Version Support page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,7 @@ layout: base
       {% endunless %}
       <a href="{{ href }}" class="btn primary">Documentation</a>
       <a href="{{ site.links.repo }}/wiki/FP-Guide" class="btn">FP Guide</a>
+      <a href="/version-support" class="btn">Version Support</a>
     </div>
   </div>
 </header>

--- a/assets/css/_version-support.scss
+++ b/assets/css/_version-support.scss
@@ -1,0 +1,27 @@
+html.version-support {
+  .support-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.6rem 0;
+
+    th, td {
+      padding: 1.2rem 1.6rem;
+      text-align: left;
+      border-bottom: 1px solid $linkUnderline;
+    }
+
+    th {
+      font-weight: 600;
+      color: $defaultColor;
+    }
+
+    td:first-child {
+      font-weight: 600;
+    }
+
+    .ongoing {
+      color: $brandMain;
+      font-weight: 600;
+    }
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -8,5 +8,6 @@
 {% include_relative  _home.scss %}
 {% include_relative  _docs.scss %}
 {% include_relative  _custom-builds.scss %}
+{% include_relative  _version-support.scss %}
 {% include_relative  _syntax-highlight.scss %}
 {% include_relative  _media-queries.scss %}

--- a/version-support.html
+++ b/version-support.html
@@ -1,0 +1,59 @@
+---
+id: version-support
+title: Lodash version support
+layout: default
+---
+
+<section>
+  <h1>Version Support</h1>
+  <p>Only the latest version of any given major release line is supported.</p>
+  <p>Versions that are EOL (end-of-life) may receive updates for critical security vulnerabilities, but the lodash team offers no guarantee and does not plan to address or release fixes for any issues found.</p>
+</section>
+
+<section>
+  <h2>Support Timeline</h2>
+  <table class="support-table">
+    <thead>
+      <tr>
+        <th>Version</th>
+        <th>Support Start</th>
+        <th>Support End</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>v4.x</td>
+        <td>January 2016</td>
+        <td><span class="ongoing">ongoing</span></td>
+      </tr>
+      <tr>
+        <td>v3.x</td>
+        <td>January 2015</td>
+        <td>January 2016</td>
+      </tr>
+      <tr>
+        <td>v2.x</td>
+        <td>September 2013</td>
+        <td>January 2015</td>
+      </tr>
+      <tr>
+        <td>v1.x</td>
+        <td>February 2013</td>
+        <td>September 2013</td>
+      </tr>
+      <tr>
+        <td>v0.x</td>
+        <td>April 2012</td>
+        <td>February 2013</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section>
+  <h2>Commercial Support Options</h2>
+  <p>If you are unable to update to a supported version of lodash, please consider:</p>
+  <ul class="chevron">
+    <li><a href="https://www.herodevs.com/support/lodash-nes?utm_source=lodash&utm_medium=link&utm_campaign=lodash_eol_page">HeroDevs Never-Ending Support</a></li>
+  </ul>
+</section>


### PR DESCRIPTION
Adds a new page showing lodash version support timeline and EOL policy, similar to expressjs.com/en/support/. Includes link to HeroDevs NES for commercial support of EOL versions.